### PR TITLE
fix: Use correct /check API call

### DIFF
--- a/src/app/check/controllers/national-insurance-number.js
+++ b/src/app/check/controllers/national-insurance-number.js
@@ -13,8 +13,7 @@ class NationalInsuranceNumberController extends BaseController {
         await req.axios.post(
           CHECK,
           {
-            key: "nino",
-            value: req.sessionModel.get("nationalInsuranceNumber"),
+            nino: req.sessionModel.get("nationalInsuranceNumber"),
           },
           {
             headers: {

--- a/tests/imposter/private-api-config.yaml
+++ b/tests/imposter/private-api-config.yaml
@@ -54,22 +54,21 @@ resources:
     path: /session
     requestBody:
       jsonPath: $.client_id
-      value: "session-400"
-    response:
-      statusCode: 400
-      template: true
-      content: "{}"
-
-  - method: POST
-    path: /session
-    requestBody:
-      jsonPath: $.client_id
       value: "session-500"
     response:
       statusCode: 500
       template: true
       content: |
         {}
+
+  - method: POST
+    path: /session
+    requestBody:
+      jsonPath: $.client_id
+    response:
+      statusCode: 400
+      template: true
+      content: "{}"
 
   - method: GET
     path: /authorization
@@ -89,26 +88,8 @@ resources:
 
   - method: GET
     path: /authorization
-    requestHeaders:
-      session-id: "authorization-error"
     response:
-      statusCode: 500
-      content: |
-        {
-          "redirect_uri": "http://example.net",
-          "oauth_error": {
-            "error_description": "gateway",
-            "error": "server_error"
-          }
-        }
-
-  - method: POST
-    path: /favourite
-    requestHeaders:
-      session-id: "authorization-error"
-    response:
-      template: true
-      statusCode: 500
+      statusCode: 400
       content: |
         {
           "redirect_uri": "http://example.net",
@@ -124,9 +105,7 @@ resources:
       session-id: "success"
     requestBody:
       allOf:
-        - jsonPath: $.key
-          value: "nino"
-        - jsonPath: $.value
+        - jsonPath: $.nino
           value: "AA123455D"
     response:
       statusCode: 200
@@ -139,9 +118,7 @@ resources:
       session-id: "success"
     requestBody:
       allOf:
-        - jsonPath: $.key
-          value: "nino"
-        - jsonPath: $.value
+        - jsonPath: $.nino
           value: "RT123456A"
     response:
       statusCode: 422
@@ -156,3 +133,16 @@ resources:
       statusCode: 500
       content: |
         {}
+
+  - method: POST
+    path: /check
+    response:
+      statusCode: 500
+      content: |
+        {
+          "redirect_uri": "http://example.net",
+          "oauth_error": {
+            "error_description": "gateway",
+            "error": "server_error"
+          }
+        }

--- a/tests/imposter/private-api.yaml
+++ b/tests/imposter/private-api.yaml
@@ -27,6 +27,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+      x-amazon-apigateway-request-validator: "Validate both"
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-AuthorizationFunctionTS/invocations
+        passthroughBehavior: "when_no_match"
 
   /session:
     post:
@@ -83,26 +90,70 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-
+      x-amazon-apigateway-request-validator: "Validate both"
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-SessionFunctionTS/invocations
+        responses:
+          default:
+            statusCode: "200"
+        passthroughBehavior: "when_no_match"
+        contentHandling: "CONVERT_TO_TEXT"
+        type: "aws_proxy"
   /check:
     post:
+      summary: "IP address of the client."
       parameters:
         - $ref: "#/components/parameters/SessionHeader"
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Check"
-
+              $ref: "#/components/schemas/Nino"
+        required: true
+      x-amazon-apigateway-request-validator: "Validate both"
       responses:
         "200":
-          description: "Check received"
+          description: OK
         "400":
-          description: "General Client Error"
-        "422":
-          description: "Retry"
+          description: Bad Request
         "500":
-          description: "General Server Error"
+          description: Internal Server Error
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        passthroughBehavior: "when_no_templates"
+        type: "aws"
+        credentials:
+          Fn::Sub: ${ExecuteStateMachineRole.Arn}
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:states:action/StartSyncExecution
+        requestTemplates:
+          application/json:
+            Fn::Sub: |-
+              {
+                "input": "{\"nino\": \"$util.parseJson($input.json('$.nino').trim())\",\"sessionId\": \"$input.params('session-id').trim()\"}",
+                "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-NinoCheck"
+              }
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: |
+                #set($resp = $util.parseJson($input.body))
+                #set($params = $util.parseJson($resp.output))
+                #foreach($paramName in $params.keySet())
+                #if($paramName == 'error')
+                #set($err = true)
+                #end
+                #end
+                #if($err == true)
+                #set($context.responseOverride.status = 400)
+                #elseif($resp.status == "FAILED")
+                #set($context.responseOverride.status = 500)
+                $resp.cause
+                #end
+                $resp.output
 
 components:
   parameters:
@@ -116,8 +167,18 @@ components:
       examples:
         200:
           value: "1fbc5730-9d17-416d-b2ca-0be90e1e93f5"
-
+        400:
+          value: "fad21bea-bce9-4aa7-8889-d50c7d26616e"
+        500:
+          value: "f27b8afc-90ef-4e0f-83ad-00a2f5692590"
   schemas:
+    Nino:
+      required: true
+      type: "object"
+      properties:
+        nino:
+          type: "string"
+          example: "AA000003D"
     Authorization:
       required:
         - "client_id"
@@ -127,7 +188,7 @@ components:
         client_id:
           type: "string"
           minLength: 1
-          example: "ipv-stub"
+          example: "ipv-core-stub"
         request:
           type: "string"
     AuthorizationResponse:
@@ -151,6 +212,9 @@ components:
     Error:
       title: "Error Schema"
       type: "object"
+      properties:
+        message:
+          type: "string"
     Session:
       required:
         - "session_id"
@@ -164,12 +228,11 @@ components:
           type: "string"
         redirect_uri:
           type: "string"
-    Check:
-      type: "object"
-      properties:
-        key:
-          type: "string"
-          example: "nino"
-        value:
-          type: "string"
-          example: "AA123455D"
+
+x-amazon-apigateway-request-validators:
+  Validate both:
+    validateRequestBody: true
+    validateRequestParameters: true
+  Validate Param only:
+    validateRequestParameters: true
+    validateRequestBody: false

--- a/tests/unit/src/app/check/controllers/national-insurance-number.test.js
+++ b/tests/unit/src/app/check/controllers/national-insurance-number.test.js
@@ -32,7 +32,7 @@ describe("national insurance number", () => {
 
       expect(req.axios.post).toHaveBeenCalledWith(
         CHECK,
-        { key: "nino", value: "AA12" },
+        { nino: "AA12" },
         {
           headers: {
             "session-id": req.session.tokenId,


### PR DESCRIPTION
- Update OpenAPI config from ipv-cri-check-hmrc-api
- Update Imposter config based upon OpenAPI config
- Update API call and unit tests

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

OpenAPI config use a payload of a format `{ nino: "AABC"}` not `{ key: "nino", value: "AABC"}`
 
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
