### PR TITLE
OJ-1922-Add-validator-for-NINO

### DIFF
--- a/src/app/check/fields.js
+++ b/src/app/check/fields.js
@@ -1,3 +1,5 @@
+const { isValidNino } = require("../../lib/validator");
+
 module.exports = {
   nationalInsuranceNumber: {
     type: "text",
@@ -6,9 +8,8 @@ module.exports = {
         type: "required",
       },
       {
-        type: "maxlength",
-        fn: "maxlength",
-        arguments: [30],
+        type: "nino",
+        fn: isValidNino,
       },
     ],
   },

--- a/src/lib/validator.js
+++ b/src/lib/validator.js
@@ -1,0 +1,8 @@
+const isValidNino = (value) => {
+  return value.match(
+    "" ||
+      /^(?!BG|GB|KN|NK|NT|TN|ZZ)[ABCEGHJKLMNOPRSTWXYZ][ABCEGHJKLMNPRSTWXYZ][0-9]{6}[ABCD]$/i
+  );
+};
+
+module.exports = { isValidNino };

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -1,6 +1,7 @@
 nationalInsuranceNumber:
   content: " "
-  label: What is your national insurance number?
-  hint: It's on your National Insurance card, benefit letter, payslip or P60. For example, 'QQ123456C'
+  label: Beth yw eich rhif yswiriant gwladol? (WIP)
+  hint: Mae ar eich cerdyn Yswiriant Gwladol, llythyr budd-dal, slip cyflog neu P60. Er enghraifft, 'QQ123456C' (WIP)
   validation:
-    required: Enter your National Insurance Number
+    required: Rhowch eich Rhif Yswiriant Gwladol (WIP)
+    nino: Rhowch Rif Yswiriant Gwladol dilys (WIP)

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -4,3 +4,4 @@ nationalInsuranceNumber:
   hint: It's on your National Insurance card, benefit letter, payslip or P60. For example, 'QQ123456C'
   validation:
     required: Enter your National Insurance Number
+    nino: Enter a valid National Insurance Number

--- a/tests/browser/features/error-bad-nino.feature
+++ b/tests/browser/features/error-bad-nino.feature
@@ -1,0 +1,11 @@
+Feature: Error handling
+  Nino Errors in the middle of the journey
+
+  @mock-api:success
+  Scenario: Error Bad Nino
+    Given Happy Harriet is using the system
+    And they have started the journey
+    And they should see the national insurance number page
+    And they enter a bad national insurance number
+    When they continue from national insurance number
+    Then they should see the validation error page

--- a/tests/browser/pages/nino.js
+++ b/tests/browser/pages/nino.js
@@ -20,4 +20,8 @@ module.exports = class PlaywrightDevPage {
   async enterNINO(value) {
     await this.page.fill("#nationalInsuranceNumber", value);
   }
+
+  hasErrorSummary() {
+    return this.page.locator(".govuk-error-summary");
+  }
 };

--- a/tests/browser/step_definitions/national-insurance-number.js
+++ b/tests/browser/step_definitions/national-insurance-number.js
@@ -2,7 +2,7 @@ const { Given, Then, When } = require("@cucumber/cucumber");
 const { NinoPage } = require("../pages");
 const { expect } = require("chai");
 
-Then(/they should see the national insurance number page$/, async function () {
+Then(/^they should see the national insurance number page$/, async function () {
   const ninoPage = new NinoPage(this.page);
 
   expect(ninoPage.isCurrentPage()).to.be.true;
@@ -13,8 +13,21 @@ Then("they continue from national insurance number", async function () {
   await ninoPage.continue();
 });
 
+Then(/^they should see the validation error page$/, async function () {
+  const ninoPage = new NinoPage(this.page);
+  expect(ninoPage.isCurrentPage()).to.be.true;
+
+  expect(ninoPage.hasErrorSummary).to.not.be.false;
+});
+
 When(/^they enter their national insurance number$/, async function () {
   const ninoPage = new NinoPage(this.page);
 
   await ninoPage.enterNINO("AA123455D");
+});
+
+When(/^they enter a bad national insurance number$/, async function () {
+  const ninoPage = new NinoPage(this.page);
+
+  await ninoPage.enterNINO("QQ123456Q");
 });

--- a/tests/unit/src/lib/validator.test.js
+++ b/tests/unit/src/lib/validator.test.js
@@ -1,0 +1,109 @@
+const { isValidNino } = require("../../../../src/lib/validator");
+
+const good_edge_case_ninos = [
+  "CA283902A",
+  "EA283902A",
+  "GA283902A",
+  "HA283902A",
+  "JA283902A",
+  "PA283902A",
+  "RA283902A",
+  "TA283902A",
+  "WA283902A",
+  "AC283902A",
+  "AE283902A",
+  "AG283902A",
+  "AH283902A",
+  "AJ283902A",
+  "AN283902A",
+  "AP283902A",
+  "AR283902A",
+  "AT283902A",
+  "AW283902A",
+  "AA283902A",
+  "AA283902B",
+  "AA283902C",
+  "AA283902D",
+];
+const bad_prefixes_ninos = [
+  "DA283902A",
+  "FA283902A",
+  "IA283902A",
+  "QA283902A",
+  "UA283902A",
+  "VA283902A",
+  "AD283902A",
+  "AF283902A",
+  "AI283902A",
+  "AO283902A",
+  "AQ283902A",
+  "AU283902A",
+  "AV283902A",
+];
+const bad_unused_prefixes_ninos = [
+  "BG283902A",
+  "GB283902A",
+  "KN283902A",
+  "NK283902A",
+  "NT283902A",
+  "TN283902A",
+  "ZZ283902A",
+];
+const bad_suffixes_ninos = ["AA2839020", "AA283902E"];
+const bad_length_ninos = [
+  "AAA283902A",
+  "AA283902AA",
+  "AA2839021A",
+  "AA2839021AA",
+  "AAA2839021A",
+  "22333333A",
+  "A283902A",
+  "283902A",
+  "AA283902",
+  "A283902",
+  "283902",
+  "AA83902A",
+  "AA2A",
+  "AAA",
+  "AA",
+  "A",
+  "",
+];
+
+describe("should fail all the bad ninos", () => {
+  test.each(bad_prefixes_ninos)(
+    "given bad prefix nino of %p, returns null string",
+    (ninoArg) => {
+      const result = isValidNino(ninoArg);
+      expect(result).toBeNull();
+    }
+  );
+  test.each(bad_unused_prefixes_ninos)(
+    "given unused prefix nino of %p, returns null string",
+    (ninoArg) => {
+      const result = isValidNino(ninoArg);
+      expect(result).toBeNull();
+    }
+  );
+  test.each(bad_suffixes_ninos)(
+    "given bad suffix nino of %p, returns null string",
+    (ninoArg) => {
+      const result = isValidNino(ninoArg);
+      expect(result).toBeNull();
+    }
+  );
+  test.each(bad_length_ninos)(
+    "given bad length nino of %p, returns null string",
+    (ninoArg) => {
+      const result = isValidNino(ninoArg);
+      expect(result).toBeNull();
+    }
+  );
+});
+
+describe("should return all the good ninos", () => {
+  test.each(good_edge_case_ninos)("returns the given nino of %p", (ninoArg) => {
+    const result = isValidNino(ninoArg)[0];
+    expect(result).toEqual(ninoArg);
+  });
+});


### PR DESCRIPTION
adding validation to the Nino page.
OJ-1922

## Proposed changes

### What changed

added the validator, and attached it to the field
[update to field and validator
nino validator edge case unit tests
front-end testing for the nino validation.

### Why did it change

so that the UI has validation

### Issue tracking

[OJ-1922] - https://govukverify.atlassian.net/browse/OJ-1922

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed


- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1922]: https://govukverify.atlassian.net/browse/OJ-1922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ