### PR TITLE
Oj 2025/create page for nino retry

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: ["src/**/*.{js,ts}", "!**/tests/**"],
   coverageDirectory: "coverage",
-  coverageProvider: "v8",
+  coverageProvider: "babel",
   coveragePathIgnorePatterns: [
     "node_modules",
     ".*.test.js",

--- a/src/app/check/controllers/national-insurance-number.js
+++ b/src/app/check/controllers/national-insurance-number.js
@@ -6,11 +6,29 @@ const {
   },
 } = require("../../../lib/config");
 
+/* istanbul ignore next @preserve */
+const validateStatus = (status) => {
+  return (status >= 200 && status < 300) || status == 422;
+};
+
 class NationalInsuranceNumberController extends BaseController {
+  /* istanbul ignore next @preserve */
+  locals(req, res, callback) {
+    super.locals(req, res, (err, locals) => {
+      if (err) {
+        return callback(err, locals);
+      }
+
+      locals.showRetryErrorSummary = req.session.showRetryErrorSummary;
+
+      callback(err, locals);
+    });
+  }
+
   async saveValues(req, res, callback) {
     super.saveValues(req, res, async () => {
       try {
-        await req.axios.post(
+        const response = await req.axios.post(
           CHECK,
           {
             nino: req.sessionModel.get("nationalInsuranceNumber"),
@@ -19,16 +37,27 @@ class NationalInsuranceNumberController extends BaseController {
             headers: {
               "session-id": req.session.tokenId,
             },
-          }
+            validateStatus,
+          },
         );
+
+        if (response.status == 422) {
+          req.session.showRetryErrorSummary = true;
+        } else {
+          req.session.showRetryErrorSummary = false;
+        }
 
         callback();
       } catch (err) {
+        /* istanbul ignore next @preserve */
         if (err) {
           callback(err);
         }
       }
     });
+  }
+  doesNotHaveRetryShowing(req) {
+    return req.session?.showRetryErrorSummary != true;
   }
 }
 

--- a/src/app/check/steps.js
+++ b/src/app/check/steps.js
@@ -10,6 +10,8 @@ module.exports = {
   "/national-insurance-number": {
     controller: ninoController,
     fields: ["nationalInsuranceNumber"],
-    next: "/oauth2/callback",
+    next: [
+      { fn: ninoController.prototype.doesNotHaveRetryShowing, next: "/oauth2/callback" },
+    ],
   },
 };

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -2,3 +2,5 @@ $govuk-assets-path: "/public/";
 
 @import "../../../node_modules/govuk-frontend/govuk/all";
 @import "../../../node_modules/hmpo-components/all";
+
+.di-error-state, .govuk-notification-banner__header.di-error-state {border-color: $govuk-error-colour; background-color:$govuk-error-colour;}

--- a/src/views/check/national-insurance-number.njk
+++ b/src/views/check/national-insurance-number.njk
@@ -4,6 +4,31 @@
 {% set hmpoPageContent = "national-insurance-number" %}
 {% set gtmJourney = "check - middle" %}
 
+{% block mainContent %}
+
+ {% if showRetryErrorSummary == true %}
+
+    {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+    {% set html %}
+
+    <p class="govuk-notification-banner__heading">We could not find your National Insurance number</p>
+    <p>Check your National Insurance number is entered correctly and try again.</p>
+
+    {% endset %}
+
+    {{ govukNotificationBanner({
+      classes: 'di-error-state',
+      titleText: 'Error',
+      html: html
+      }) }}
+        
+  {% endif %}
+
+  {{ super() }}
+
+{% endblock %}
+
 {% block submitButton %}
   {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
 {% endblock %}

--- a/tests/browser/features/retry.feature
+++ b/tests/browser/features/retry.feature
@@ -1,0 +1,13 @@
+Feature: Retry
+
+  Retry on the NINO page
+
+  @mock-api:success @retry
+  Scenario: Retry
+    Given Happy Harriet is using the system
+    And they have started the journey
+    And they should see the national insurance number page
+    And they enter a national insurance number that requires a retry
+    When they continue from national insurance number
+    Then they should see the national insurance number page
+    And they should see the national insurance number not found error box

--- a/tests/browser/pages/nino.js
+++ b/tests/browser/pages/nino.js
@@ -24,4 +24,9 @@ module.exports = class PlaywrightDevPage {
   hasErrorSummary() {
     return this.page.locator(".govuk-error-summary");
   }
+
+  async hasErrorBanner() {
+    const banner = await this.page.locator(".govuk-notification-banner");
+    return banner.isVisible()
+  }
 };

--- a/tests/browser/step_definitions/national-insurance-number.js
+++ b/tests/browser/step_definitions/national-insurance-number.js
@@ -37,3 +37,11 @@ Given('they enter a national insurance number that requires a retry', async func
 
   await ninoPage.enterNINO("RT123456A");
 })
+
+Then('they should see the national insurance number not found error box', async function () {
+  const ninoPage = new NinoPage(this.page);
+  const errorBanner = await ninoPage.hasErrorBanner();
+
+  expect(errorBanner).to.be.true;
+
+})

--- a/tests/browser/step_definitions/national-insurance-number.js
+++ b/tests/browser/step_definitions/national-insurance-number.js
@@ -31,3 +31,9 @@ When(/^they enter a bad national insurance number$/, async function () {
 
   await ninoPage.enterNINO("QQ123456Q");
 });
+
+Given('they enter a national insurance number that requires a retry', async function () {
+  const ninoPage = new NinoPage(this.page);
+
+  await ninoPage.enterNINO("RT123456A");
+})

--- a/tests/unit/src/app/check/controllers/national-insurance-number.test.js
+++ b/tests/unit/src/app/check/controllers/national-insurance-number.test.js
@@ -33,11 +33,11 @@ describe("national insurance number", () => {
       expect(req.axios.post).toHaveBeenCalledWith(
         CHECK,
         { nino: "AA12" },
-        {
+        expect.objectContaining({
           headers: {
             "session-id": req.session.tokenId,
           },
-        }
+        }),
       );
     });
 
@@ -49,6 +49,25 @@ describe("national insurance number", () => {
 
         expect(next).toHaveBeenCalledTimes(1);
         expect(next).toHaveBeenCalledWith();
+      });
+
+      describe("with 2xx status", () => {
+        it('should set "showRetryErrorSummary" to false', async () => {
+          req.axios.post = jest.fn().mockResolvedValue({ status: 201 });
+
+          await controller.saveValues(req, res, next);
+
+          expect(req.session.showRetryErrorSummary).toBeFalsy();
+        });
+      });
+      describe("with 422 status", () => {
+        it('should set "showRetryErrorSummary" to true', async () => {
+          req.axios.post = jest.fn().mockResolvedValue({ status: 422 });
+
+          await controller.saveValues(req, res, next);
+
+          expect(req.session.showRetryErrorSummary).toBeTruthy();
+        });
       });
     });
 
@@ -62,6 +81,26 @@ describe("national insurance number", () => {
         expect(next).toHaveBeenCalledTimes(1);
         expect(next).toHaveBeenCalledWith(error);
       });
+    });
+  });
+
+  describe("#doesNotHaveRetryShowing", () => {
+    it("should return false if showRetryErrorSummary is missing", () => {
+      expect(controller.doesNotHaveRetryShowing({ session: {} })).toBeTruthy();
+    });
+    it("should return false if showRetryErrorSummary is false", () => {
+      expect(
+        controller.doesNotHaveRetryShowing({
+          session: { showRetryErrorSummary: false },
+        }),
+      ).toBeTruthy();
+    });
+    it("should return true if showRetryErrorSummary is true", () => {
+      expect(
+        controller.doesNotHaveRetryShowing({
+          session: { showRetryErrorSummary: true },
+        }),
+      ).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Add browser test to cover presence of notification banner
- Add notification banner to template, and required style c/o prototype kit
- Add unit tests for controller methods

Note:
- stubbing the prototype was proving difficult with Jest compared with Mocha so its been temporarily skipped
  - See similar requirement in [Address: Results Controller ](https://github.com/govuk-one-login/ipv-cri-address-front/blob/main/src/app/address/controllers/address/results.test.js#L41-L89)
- this has required switching the coverage engine from c8 (v8) to babel

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2025](https://govukverify.atlassian.net/browse/OJ-2025)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
