### PR TITLE
chore: Update govuk-frontend and hmpo* packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "express-session": "1.17.3",
         "govuk-frontend": "4.7.0",
         "hmpo-app": "3.0.1",
-        "hmpo-components": "6.3.0",
+        "hmpo-components": "6.4.0",
         "hmpo-form-wizard": "13.0.0",
         "hmpo-i18n": "6.0.1",
         "hmpo-logger": "7.0.1",
@@ -3951,6 +3951,19 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -4335,9 +4348,9 @@
       }
     },
     "node_modules/hmpo-components": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-6.3.0.tgz",
-      "integrity": "sha512-0PVDp6lgYtJM/heul56qkWHTgLh0Xz5cClrFQ+09QU2t5YEsTIOqwwkksIChP6/af8TJAGkXuKyJY/vOya3cEg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-6.4.0.tgz",
+      "integrity": "sha512-iJqkD3qV8UY6SzJMAocRj3zgZv4MHCpMdHmxjmVOsVZZrwkfADy6RPEhKPm86WH79gEQ3gyYLhhpG1CHX4XNtw==",
       "dependencies": {
         "bytes": "^3.1.2",
         "deep-clone-merge": "^1.5.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "express-session": "1.17.3",
     "govuk-frontend": "4.7.0",
     "hmpo-app": "3.0.1",
-    "hmpo-components": "6.3.0",
+    "hmpo-components": "6.4.0",
     "hmpo-form-wizard": "13.0.0",
     "hmpo-i18n": "6.0.1",
     "hmpo-logger": "7.0.1",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Update to 4.7 of govuk-frontend
- Update to latest version of hmpo packages
  - breaking changes are all to do with dropping support for Node 12
  
<!-- Describe the changes in detail - the "what"-->
