### PR TITLE
IPS-493: Update post-merge workflow to use devplatform-upload-action-ecr

### DIFF
--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -24,12 +24,17 @@ jobs:
           registry: khw46367.live.dynatrace.com
           username: khw46367
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+
+      - name: SAM Validate
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
+
       - name: "Push signed image to ECR, updated SAM template with image then upload it to the S3 Artifact Bucket"
-        uses: alphagov/di-devplatform-upload-action-ecr@1.0.3
+        uses: govuk-one-login/devplatform-upload-action-ecr@1.2.0
         with:
           artifact-bucket-name: ${{ secrets[format('{0}_{1}', matrix.environment, 'ARTIFACT_BUCKET_NAME')] }}
           container-sign-kms-key-arn: ${{ secrets[format('{0}_{1}', matrix.environment, 'CONTAINER_SIGN_KMS_KEY')] }}
           working-directory: .
           template-file: deploy/template.yaml
+          docker-build-path: .
           role-to-assume-arn: ${{ secrets[format('{0}_{1}', matrix.environment, 'GH_ACTIONS_ROLE_ARN')] }}
           ecr-repo-name: ${{ secrets[format('{0}_{1}', matrix.environment, 'ECR_NAME_FRONT')] }}

--- a/.github/workflows/post-merge-to-dev.yml
+++ b/.github/workflows/post-merge-to-dev.yml
@@ -26,10 +26,16 @@ jobs:
           registry: khw46367.live.dynatrace.com
           username: khw46367
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+
+      - name: SAM Validate
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
+
       - name: "Push signed image to ECR, updated SAM template with image then upload it to the S3 Artifact Bucket"
-        uses: govuk-one-login/devplatform-upload-action-ecr@1.0.5
+        uses: govuk-one-login/devplatform-upload-action-ecr@1.2.0
         with:
           artifact-bucket-name: ${{ secrets[format('{0}_{1}', matrix.environment, 'ARTIFACT_BUCKET_NAME')] }}
           template-file: deploy/template.yaml
+          working-directory: .
+          docker-build-path: .
           role-to-assume-arn: ${{ secrets[format('{0}_{1}', matrix.environment, 'GH_ACTIONS_ROLE_ARN')] }}
           ecr-repo-name: ${{ secrets[format('{0}_{1}', matrix.environment, 'ECR_NAME_FRONT')] }}


### PR DESCRIPTION
### What changed

- Updated post-merge workflow to use devplatform-upload-action-ecr@1.2.0

### Why did it change

- Required for canary deployments across Identity

### Issue tracking
- [IPS-493](https://govukverify.atlassian.net/browse/IPS-493)
- [IPS-532](https://govukverify.atlassian.net/browse/IPS-532)

## Checklists

### Evidence
- Image successfully pushed to dev, with commit tag, by manually triggering workflow:
https://github.com/govuk-one-login/ipv-cri-check-hmrc-front/actions/runs/7932030114

![Screenshot 2024-02-16 at 14 55 09](https://github.com/govuk-one-login/ipv-cri-check-hmrc-front/assets/153090281/ac935d9f-df21-479b-8a74-b939fcaa1ac9)

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-493]: https://govukverify.atlassian.net/browse/IPS-493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IPS-532]: https://govukverify.atlassian.net/browse/IPS-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ