### PR TITLE
OJ-2160 nino check perf test 100 percent cpu failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+.aws-sam

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -574,7 +574,7 @@ Resources:
     Condition: IsProductionOrBuild
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
-      MaxCapacity: 4
+      MaxCapacity: 60
       MinCapacity: 2
       ResourceId: !Join
         - "/"


### PR DESCRIPTION
## Proposed changes

### What changed

- Increased the maximum number of tasks the ecs service can scale out to 

### Why did it change

- Match the max scaling of other repos such as address and fraud
- There were failing performance tests


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2160](https://govukverify.atlassian.net/browse/OJ-2160)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
