### PR TITLE
IPS-676: Implement subscription filter for CSLS logging

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 package-lock.json
+deploy/template.yaml

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -29,26 +29,7 @@ Parameters:
     Type: String
     Default: "none"
 
-  CriIdentifier:
-    Description: "The unique credential issuer identifier"
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: "/common-cri-parameters/CriIdentifier"
-
 Conditions:
-  IsCSLSDisabled: !And
-    - !Not
-      - !Or
-        - !Equals [!Ref CriIdentifier, "di-ipv-cri-hmrc-check-api"]
-        - !Equals [!Ref CriIdentifier, "di-ipv-cri-check-hmrc-api"]
-        - !Equals [!Ref CriIdentifier, "di-ipv-cri-hmrc-kbv-api"]
-    - !Not
-      - !Or
-        - !Equals [!Ref Environment, "dev"]
-        - !Equals [!Ref Environment, "build"]
-        - !Equals [!Ref Environment, "staging"]
-        - !Equals [!Ref Environment, "integration"]
-        - !Equals [!Ref Environment, "production"]
-
   IsNotDevelopment: !Or
     - !Equals [!Ref Environment, build]
     - !Equals [!Ref Environment, staging]
@@ -83,6 +64,18 @@ Mappings:
   ElasticLoadBalancerAccountIds:
     eu-west-2:
       AccountId: 652711504416
+
+  PlatformConfiguration:
+    dev:
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+    build:
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+    staging:
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+    integration:
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
+    production:
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
 
 Resources:
   # Security Groups for the ECS service and load balancer
@@ -292,11 +285,12 @@ Resources:
       LogGroupName: !Sub /aws/ecs/${AWS::StackName}-Front-ECS
       RetentionInDays: 14
 
-  ECSAccessLogsGroupSubscriptionFilterCSLS:
+  ECSLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsCSLSDisabled
+    Condition: IsNotDevelopment
     Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      DestinationArn:
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref ECSAccessLogsGroup
 
@@ -558,11 +552,12 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-API-GW-AccessLogs
 
-  APIGWAccessLogsGroupSubscriptionFilterCSLS:
+  APIGWLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsCSLSDisabled
+    Condition: IsNotDevelopment
     Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      DestinationArn:
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref APIGWAccessLogsGroup
 


### PR DESCRIPTION
## Proposed changes
- Implement Subscription filter for CSLS logging

### What changed
- Add CSLSEGRESS ARNs for all the environments
- Add subscription filters for the ECS and API GW

### Why did it change

- Add subscription filters to inject logs into splunk

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-676](https://govukverify.atlassian.net/browse/IPS-676)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-676]: https://govukverify.atlassian.net/browse/IPS-676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ