### PR TITLE
IPS-650 add rarning alerts on ECS autoscaling

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -740,6 +740,9 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref StepScaleOutPolicy
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "FrontClusterOver60PercentCPU. ${SupportManualURL}"
       ComparisonOperator: "GreaterThanThreshold"
       DatapointsToAlarm: "2"
@@ -764,6 +767,9 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref StepScaleInPolicy
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: "FrontClusterUnder60PercentCPU"
       ComparisonOperator: "LessThanThreshold"
       DatapointsToAlarm: "5"


### PR DESCRIPTION
## Proposed changes

### What changed

Added warning alerts on ECS Autoscaling

### Why did it change

There was no alerting on the AutoScaling

### Issue tracking

- [IPS-650](https://govukverify.atlassian.net/browse/IPS-650)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-650]: https://govukverify.atlassian.net/browse/IPS-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ