### PR TITLE
Add content-type header to /abandon request

### DIFF
--- a/src/app/check/controllers/abandon.js
+++ b/src/app/check/controllers/abandon.js
@@ -12,6 +12,7 @@ class AbandonController extends BaseController {
       await req.axios.post(ABANDON, undefined, {
         headers: {
           "session-id": req.session.tokenId,
+          "Content-Type": "application/json",
         },
       });
       super.saveValues(req, res, async () => callback());

--- a/tests/imposter/private-api.yaml
+++ b/tests/imposter/private-api.yaml
@@ -162,6 +162,11 @@ paths:
       summary: "IP address of the client."
       parameters:
         - $ref: "#/components/parameters/SessionHeader"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EmptyBody"
       x-amazon-apigateway-request-validator: "Validate both"
       responses:
         "200":
@@ -217,6 +222,9 @@ components:
         500:
           value: "f27b8afc-90ef-4e0f-83ad-00a2f5692590"
   schemas:
+    EmptyBody:
+      type: object
+      nullable: true
     Nino:
       required: true
       type: "object"

--- a/tests/unit/src/app/check/controllers/abandon.test.js
+++ b/tests/unit/src/app/check/controllers/abandon.test.js
@@ -27,12 +27,13 @@ describe("abandon", () => {
       req.form.values.nationalInsuranceNumber = "AA12";
     });
 
-    it("should call check endpoint", async () => {
+    it("should call abandon endpoint", async () => {
       await controller.saveValues(req, res, next);
 
       expect(req.axios.post).toHaveBeenCalledWith(ABANDON, undefined, {
         headers: {
           "session-id": req.session.tokenId,
+          "Content-Type": "application/json",
         },
       });
     });


### PR DESCRIPTION
## Proposed changes

### What and Why did it change
Added the header `content-type: application/json` to the `/abandon` API request as this is a required header. Without it, we are getting an "invalid media type" error being returned by AWS. 
