### PR TITLE
Added empty request body to /abandon request

### DIFF
--- a/src/app/check/controllers/abandon.js
+++ b/src/app/check/controllers/abandon.js
@@ -14,6 +14,7 @@ class AbandonController extends BaseController {
           "session-id": req.session.tokenId,
           "Content-Type": "application/json",
         },
+        data: {},
       });
       super.saveValues(req, res, async () => callback());
     } catch (err) {

--- a/tests/unit/src/app/check/controllers/abandon.test.js
+++ b/tests/unit/src/app/check/controllers/abandon.test.js
@@ -35,6 +35,7 @@ describe("abandon", () => {
           "session-id": req.session.tokenId,
           "Content-Type": "application/json",
         },
+        data: {},
       });
     });
 


### PR DESCRIPTION
## Proposed changes

### Why did it change
When specifying a content-type, AWS requires that the body of specified content-type to set. This PR sets the request body as an empty JSON to satisfy AWSs behavior. 