### PR TITLE
Fix post body to /abandon endpoint

### DIFF
--- a/src/app/check/controllers/abandon.js
+++ b/src/app/check/controllers/abandon.js
@@ -9,13 +9,16 @@ const {
 class AbandonController extends BaseController {
   async saveValues(req, res, callback) {
     try {
-      await req.axios.post(ABANDON, undefined, {
-        headers: {
-          "session-id": req.session.tokenId,
-          "Content-Type": "application/json",
-        },
-        data: {},
-      });
+      await req.axios.post(
+        ABANDON,
+        {},
+        {
+          headers: {
+            "session-id": req.session.tokenId,
+            "Content-Type": "application/json",
+          },
+        }
+      );
       super.saveValues(req, res, async () => callback());
     } catch (err) {
       if (err) {

--- a/tests/imposter/private-api-config.yaml
+++ b/tests/imposter/private-api-config.yaml
@@ -158,6 +158,8 @@ resources:
 
   - method: POST
     path: /abandon
+    requestHeaders:
+      content-type: application/json
     response:
       statusCode: 200
       content: |

--- a/tests/unit/src/app/check/controllers/abandon.test.js
+++ b/tests/unit/src/app/check/controllers/abandon.test.js
@@ -30,13 +30,16 @@ describe("abandon", () => {
     it("should call abandon endpoint", async () => {
       await controller.saveValues(req, res, next);
 
-      expect(req.axios.post).toHaveBeenCalledWith(ABANDON, undefined, {
-        headers: {
-          "session-id": req.session.tokenId,
-          "Content-Type": "application/json",
-        },
-        data: {},
-      });
+      expect(req.axios.post).toHaveBeenCalledWith(
+        ABANDON,
+        {},
+        {
+          headers: {
+            "session-id": req.session.tokenId,
+            "Content-Type": "application/json",
+          },
+        }
+      );
     });
 
     describe("on API success", () => {


### PR DESCRIPTION
## Proposed changes

### What changed
The post body was set incorrectly so this PR fixes that. Additionally, the content-type is enforced in the imposter config.