### PR TITLE
Revert "BAU: Bump hmpo-components from 6.4.0 to 6.5.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "express-session": "1.18.0",
         "govuk-frontend": "4.8.0",
         "hmpo-app": "3.0.1",
-        "hmpo-components": "6.5.0",
+        "hmpo-components": "6.4.0",
         "hmpo-form-wizard": "13.0.0",
         "hmpo-i18n": "6.0.1",
         "hmpo-logger": "7.0.1",
@@ -4316,9 +4316,9 @@
       }
     },
     "node_modules/hmpo-components": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-6.5.0.tgz",
-      "integrity": "sha512-ZX3773FHNuFhcgkyy4JISBLPP1a6bqlY/nxmQNGndOum5CWEFNu2Om/y9WFHCCPkJN6fQ5ppQKyZ9zUm8Pe42A==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-6.4.0.tgz",
+      "integrity": "sha512-iJqkD3qV8UY6SzJMAocRj3zgZv4MHCpMdHmxjmVOsVZZrwkfADy6RPEhKPm86WH79gEQ3gyYLhhpG1CHX4XNtw==",
       "dependencies": {
         "bytes": "^3.1.2",
         "deep-clone-merge": "^1.5.5",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "express-session": "1.18.0",
     "govuk-frontend": "4.8.0",
     "hmpo-app": "3.0.1",
-    "hmpo-components": "6.5.0",
+    "hmpo-components": "6.4.0",
     "hmpo-form-wizard": "13.0.0",
     "hmpo-i18n": "6.0.1",
     "hmpo-logger": "7.0.1",


### PR DESCRIPTION
This reverts commit 5d2ac8561c94ee8369a1d3a6ee355f74243dab42.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Reverting due to UI inclusion of `prefix` on input field

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
