### PR TITLE
log retention settings have been updated to 30 days

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -302,7 +302,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/ecs/${AWS::StackName}-Front-ECS
-      RetentionInDays: 14
+      RetentionInDays: 30
 
   ECSLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
@@ -624,6 +624,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-API-GW-AccessLogs
+      RetentionInDays: 30
 
   APIGWLogsSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Updated all log group retention days to 30

See https://govukverify.atlassian.net/browse/SW-259 and associated epic https://govukverify.atlassian.net/browse/SW-241

### Why did it change

Currently any log retention that is set under 30 days will be set to 30 by a Lambda attached to the LZA Lambda run

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
