### PR TITLE
Remove - GOV.UK from the page titles to use the CE template as intended

### DIFF
--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -1,14 +1,14 @@
 national-insurance-number:
-  title: "Rhowch eich Rhif Yswiriant Gwladol - GOV.UK One Login"
+  title: "Rhowch eich Rhif Yswiriant Gwladol"
   h1: "Rhowch eich Rhif Yswiriant Gwladol"
   content:
     - Byddwn yn gwirio eich rhif Yswiriant Gwladol gyda Chyllid a Thollau EF (CThEF) fel rhan o brofi eich hunaniaeth.
     - Gallwch ddod o hyd i'ch rhif Yswiriant Gwladol ar eich slip cyflog, P60 neu lythyr budd-dal.
 could-not-match-national-insurance:
-  title: "Nid oeddem yn gallu dod o hyd i wybodaeth sy'n cyfateb â'ch rhif Yswiriant Gwladol - GOV.UK One Login"
+  title: "Nid oeddem yn gallu dod o hyd i wybodaeth sy'n cyfateb â'ch rhif Yswiriant Gwladol"
   h1: Nid oeddem yn gallu dod o hyd i wybodaeth sy'n cyfateb â'ch rhif Yswiriant Gwladol
   content:
     - Nid oeddem yn gallu dod o hyd i wybodaeth sy'n cyfateb i'ch rhif Yswiriant Gwladol pan wnaethom wirio gyda CThEF.
     - Gallwch wirio eich rhif Yswiriant Gwladol a cheisio eto. Dim ond unwaith y gallwch wneud hyn.
 abandon:
-  title: "Beth hoffech chi ei wneud - Welcome to GOV.UK  One Login"
+  title: "Beth hoffech chi ei wneud"

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -1,14 +1,14 @@
 national-insurance-number:
-  title: "Enter your National Insurance Number - Welcome to GOV.UK  One Login"
+  title: "Enter your National Insurance Number"
   h1: "Enter your National Insurance number"
   content:
     - We’ll check your National Insurance number with HM Revenue and Customs (HMRC) as part of proving your identity.
     - You can find your National Insurance number on your payslip, P60 or benefit letter.
 could-not-match-national-insurance:
-  title: "We could not match your National Insurance number - GOV.UK One Login"
+  title: "We could not match your National Insurance number"
   h1: We could  not match your National Insurance number
   content:
     - We could not find a match for your National Insurance number when we checked with HMRC.
     - You can check your National Insurance number and try again. You’ll only be able to do this once.
 abandon:
-  title: "What would you like to do - Welcome to GOV.UK  One Login"
+  title: "What would you like to do"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

Removed '- ... GOV.UK' from the page titles.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

This was raised as a accessibility issue due to inconsistent page title naming. We use the CE template to standardise the titles, so we now only need to provide the page title itself. Format here: https://github.com/HMPO/hmpo-components/blob/master/components/hmpo-template.njk#L13

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2529](https://govukverify.atlassian.net/browse/OJ-2529)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2529]: https://govukverify.atlassian.net/browse/OJ-2529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ