### PR TITLE
Revert "BAU: Bump hmpo-components from 6.4.0 to 6.5.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "express-session": "1.18.0",
         "govuk-frontend": "4.8.0",
         "hmpo-app": "3.0.1",
-        "hmpo-components": "6.5.0",
+        "hmpo-components": "6.4.0",
         "hmpo-form-wizard": "13.0.0",
         "hmpo-i18n": "6.0.1",
         "hmpo-logger": "7.0.1",
@@ -5840,9 +5840,9 @@
       }
     },
     "node_modules/hmpo-components": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-6.5.0.tgz",
-      "integrity": "sha512-ZX3773FHNuFhcgkyy4JISBLPP1a6bqlY/nxmQNGndOum5CWEFNu2Om/y9WFHCCPkJN6fQ5ppQKyZ9zUm8Pe42A==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-6.4.0.tgz",
+      "integrity": "sha512-iJqkD3qV8UY6SzJMAocRj3zgZv4MHCpMdHmxjmVOsVZZrwkfADy6RPEhKPm86WH79gEQ3gyYLhhpG1CHX4XNtw==",
       "dependencies": {
         "bytes": "^3.1.2",
         "deep-clone-merge": "^1.5.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "express-session": "1.18.0",
     "govuk-frontend": "4.8.0",
     "hmpo-app": "3.0.1",
-    "hmpo-components": "6.5.0",
+    "hmpo-components": "6.4.0",
     "hmpo-form-wizard": "13.0.0",
     "hmpo-i18n": "6.0.1",
     "hmpo-logger": "7.0.1",


### PR DESCRIPTION
Reverts govuk-one-login/ipv-cri-check-hmrc-front#146

6.5.0 broke the frontend: 

![image](https://github.com/govuk-one-login/ipv-cri-check-hmrc-front/assets/76599223/d6f1271c-b1ef-4f7d-b947-39ba3d8469f1)
