### PR TITLE
BAU: Upgrades hmpo-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "express-session": "1.18.0",
         "govuk-frontend": "4.8.0",
         "hmpo-app": "3.0.1",
-        "hmpo-components": "6.4.0",
+        "hmpo-components": "6.5.0",
         "hmpo-form-wizard": "13.0.0",
         "hmpo-i18n": "6.0.1",
         "hmpo-logger": "7.0.1",
@@ -5840,9 +5840,9 @@
       }
     },
     "node_modules/hmpo-components": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-6.4.0.tgz",
-      "integrity": "sha512-iJqkD3qV8UY6SzJMAocRj3zgZv4MHCpMdHmxjmVOsVZZrwkfADy6RPEhKPm86WH79gEQ3gyYLhhpG1CHX4XNtw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-6.5.0.tgz",
+      "integrity": "sha512-ZX3773FHNuFhcgkyy4JISBLPP1a6bqlY/nxmQNGndOum5CWEFNu2Om/y9WFHCCPkJN6fQ5ppQKyZ9zUm8Pe42A==",
       "dependencies": {
         "bytes": "^3.1.2",
         "deep-clone-merge": "^1.5.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "express-session": "1.18.0",
     "govuk-frontend": "4.8.0",
     "hmpo-app": "3.0.1",
-    "hmpo-components": "6.4.0",
+    "hmpo-components": "6.5.0",
     "hmpo-form-wizard": "13.0.0",
     "hmpo-i18n": "6.0.1",
     "hmpo-logger": "7.0.1",

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -1,5 +1,6 @@
 nationalInsuranceNumber:
   content: " "
+  prefix: ""
   label: "Yswiriant Gwladol"
   hint: "Er enghraifft, 'QQ 12 34 56 C'."
 

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -1,5 +1,6 @@
 nationalInsuranceNumber:
   content: " "
+  prefix: ""
   label: "National Insurance number"
   hint: "For example, ‘QQ 12 34 56 C’."
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Upgrades hmpo-components
- Adds default value for prefix for text fields

### Screenshots
<img width="1138" alt="image" src="https://github.com/govuk-one-login/ipv-cri-check-hmrc-front/assets/40401118/47c77cd7-6e9f-4b02-abca-0823e863aea6">

![image](https://github.com/govuk-one-login/ipv-cri-check-hmrc-front/assets/40401118/5f65b1bb-414a-400b-8ff9-c8e19f96e1e8)


