### PR TITLE
BAU: Change dependabot to run weekly instead of daily

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       time: "03:00"
     target-branch: main
     labels:
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: docker
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       time: "03:00"
     target-branch: main
     labels:
@@ -28,7 +28,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     target-branch: main
     labels:
       - dependabot


### PR DESCRIPTION
Dependabot running daily isn't consistent with how the other repos are configured and makes it harder for us to keep track of.  