### PR TITLE
IPS-728 HMRC Check WAF association

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -677,6 +677,12 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
+  CloudFrontWAFv2ACLAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties:
+      ResourceArn: !Ref LoadBalancer
+      WebACLArn: !ImportValue cfront-origin-distrib-CloakingOriginWebACLArn
+
   # ECS Autoscaling
   # The number of pods will increase when the configured CPU utilization is breached for more than 3 minutes.
   # Scaling down will occur after 15 minutes of 90% utilization of the configured CPU utilization.


### PR DESCRIPTION
## Proposed changes

### What changed

Added WAF association as part of the cloudfront work

### Why did it change

There is a requirement for a WAF

### Issue tracking

- [IPS-728](https://govukverify.atlassian.net/browse/IPS-728)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-728]: https://govukverify.atlassian.net/browse/IPS-728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ