### PR TITLE
IPS-552: Enable canary deployment (stage 2)

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1178,12 +1178,10 @@ Resources:
           MetricStat:
             Metric:
               Namespace: ECS/ContainerInsights
-              MetricName: RunningTaskCount
+              MetricName: TaskCount
               Dimensions:
                 - Name: ClusterName
                   Value: !Ref EcsCluster
-                - Name: ServiceName
-                  Value: !GetAtt EcsService.Name
             Period: 60
             Stat: Minimum
 
@@ -1211,10 +1209,12 @@ Resources:
           MetricStat:
             Metric:
               Namespace: ECS/ContainerInsights
-              MetricName: TaskCount
+              MetricName: RunningTaskCount
               Dimensions:
                 - Name: ClusterName
                   Value: !Ref EcsCluster
+                - Name: ServiceName
+                  Value: !GetAtt EcsService.Name
             Period: 60
             Stat: Minimum
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -325,18 +325,22 @@ Resources:
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
-      # LoadBalancers:
-      #   - ContainerName: app
-      #     ContainerPort: 8080
-      #     TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
-      # NetworkConfiguration:
-      #   AwsvpcConfiguration:
-      #     AssignPublicIp: DISABLED
-      #     SecurityGroups:
-      #       - !GetAtt ECSSecurityGroup.GroupId
-      #     Subnets:
-      #       - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
-      #       - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB"
+      LoadBalancers: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - - ContainerName: app
+            ContainerPort: 8080
+            TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
+      NetworkConfiguration: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - AwsvpcConfiguration:
+            AssignPublicIp: DISABLED
+            SecurityGroups:
+              - !GetAtt ECSSecurityGroup.GroupId
+            Subnets:
+              - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
+              - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB"
       TaskDefinition: !If
         - UseCanaryDeployment
         - !Ref AWS::NoValue

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -325,19 +325,22 @@ Resources:
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
-      LoadBalancers:
-        - ContainerName: app
-          ContainerPort: 8080
-          TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: DISABLED
-          SecurityGroups:
-            - !GetAtt ECSSecurityGroup.GroupId
-          Subnets:
-            - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
-            - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB"
-      TaskDefinition: !Ref ECSServiceTaskDefinition
+      # LoadBalancers:
+      #   - ContainerName: app
+      #     ContainerPort: 8080
+      #     TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
+      # NetworkConfiguration:
+      #   AwsvpcConfiguration:
+      #     AssignPublicIp: DISABLED
+      #     SecurityGroups:
+      #       - !GetAtt ECSSecurityGroup.GroupId
+      #     Subnets:
+      #       - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
+      #       - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB"
+      TaskDefinition: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - !Ref ECSServiceTaskDefinition
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-ECS"


### PR DESCRIPTION
To be merged after https://github.com/govuk-one-login/ipv-cri-check-hmrc-front/pull/248

### What changed

- Updated TaskDefintion
- Removed NetworkConfiguration and LoadBalancers property from your ECS Service resource. 

### Why did it change

- Second of 2 PRs to enable canary deployments
- To enable canary deployments
- Other config commented out to avoid errors, see step 7: https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3821732161/ECS+-+Canary+Deployments+Migration+Guidance

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-532](https://govukverify.atlassian.net/browse/IPS-532)
- [IPS-552](https://govukverify.atlassian.net/browse/IPS-552)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-532]: https://govukverify.atlassian.net/browse/IPS-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IPS-552]: https://govukverify.atlassian.net/browse/IPS-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ