### PR TITLE
OJ-2759: Use `frontend-vital-signs` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@govuk-one-login/frontend-analytics": "2.0.1",
         "@govuk-one-login/frontend-language-toggle": "1.1.0",
         "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
+        "@govuk-one-login/frontend-vital-signs": "0.0.4",
         "axios": "1.6.7",
         "cfenv": "1.2.4",
         "connect-dynamodb": "3.0.3",
@@ -1553,6 +1554,14 @@
       "integrity": "sha512-Tg8bh40F9cQHi13WpuwskI5wT0kgdgnl9l6I6kxKmlIWxL07tVbfS3MxDGVTXUttQfhnJvKKEem2hJr8LLA/dw==",
       "dependencies": {
         "forwarded-parse": "^2.1.2",
+        "pino": "^8.20.0"
+      }
+    },
+    "node_modules/@govuk-one-login/frontend-vital-signs": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-vital-signs/-/frontend-vital-signs-0.0.4.tgz",
+      "integrity": "sha512-IXPZowxi2uxdbMquk2jnTNMr3sYh1Nc3R1UGOTXhad3ta7vYQy1acm/Z9Dux3L2g5xYp9He+cFJFUoOqtMi8FA==",
+      "dependencies": {
         "pino": "^8.20.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@govuk-one-login/frontend-analytics": "2.0.1",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
+    "@govuk-one-login/frontend-vital-signs": "0.0.4",
     "axios": "1.6.7",
     "cfenv": "1.2.4",
     "connect-dynamodb": "3.0.3",

--- a/src/app.js
+++ b/src/app.js
@@ -55,6 +55,9 @@ const sessionConfig = {
 };
 
 const helmetConfig = require("@govuk-one-login/di-ipv-cri-common-express/src/lib/helmet");
+const {
+  frontendVitalSignsInitFromApp,
+} = require("@govuk-one-login/frontend-vital-signs");
 
 const { app, router } = setup({
   config: { APP_ROOT: __dirname },
@@ -84,6 +87,25 @@ const { app, router } = setup({
     cookie: { name: "lng" },
   },
   middlewareSetupFn: (app) => {
+    frontendVitalSignsInitFromApp(app, {
+      interval: 60000,
+      logLevel: "info",
+      metrics: [
+        "requestsPerSecond",
+        "avgResponseTime",
+        "maxConcurrentConnections",
+        "eventLoopDelay",
+        "eventLoopUtilization",
+      ],
+      staticPaths: [
+        /^\/assets\/.*/,
+        "/ga4-assets",
+        "/javascript",
+        "/javascripts",
+        "/images",
+        "/stylesheets",
+      ],
+    });
     app.use(setHeaders);
   },
   dev: true,


### PR DESCRIPTION
## Proposed changes

### What changed
Added `frontend-vital-signs` package and initialised it within app.js

### Why did it change
To collect node metrics to help us with observability around performance and system health.

## Test Evidence
CloudWatch logs showing the logging from `frontend-vital-signs`:
![image](https://github.com/user-attachments/assets/25e860ca-3605-42bc-8098-e54fffc17ffc)

No frontend breakages occurred:
![image](https://github.com/user-attachments/assets/dd180ce0-2071-46e3-9518-bbe43aeaf2f5)

### Issue tracking
- [OJ-2759](https://govukverify.atlassian.net/browse/OJ-2759)

[OJ-2759]: https://govukverify.atlassian.net/browse/OJ-2759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ