### PR TITLE
OJ-2759: Create metrics for `frontend-vital-signs` package

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1334,6 +1334,79 @@ Resources:
             ]
           }
 
+  # Metrics for frontend-vital-signs
+  EventLoopDelayMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ECSAccessLogsGroup
+      FilterPattern: "{($.eventLoopDelay = *)}"
+      MetricTransformations:
+        - MetricValue: $.eventLoopDelay
+          MetricName: EventLoopDelay
+          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
+
+  EventLoopUtilizationIdleMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ECSAccessLogsGroup
+      FilterPattern: "{ $.eventLoopUtilization.utilization.idle = * }"
+      MetricTransformations:
+        - MetricValue: $.eventLoopUtilization.utilization.idle
+          MetricName: EventLoopUtilizationIdle
+          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
+
+  EventLoopUtilizationActiveMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ECSAccessLogsGroup
+      FilterPattern: "{ $.eventLoopUtilization.utilization.active = * }"
+      MetricTransformations:
+        - MetricValue: $.eventLoopUtilization.utilization.active
+          MetricName: EventLoopUtilizationActive
+          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
+
+  EventLoopUtilizationUtilizationMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ECSAccessLogsGroup
+      FilterPattern: "{ $.eventLoopUtilization.utilization.utilization = * }"
+      MetricTransformations:
+        - MetricValue: $.eventLoopUtilization.utilization.utilization
+          MetricName: EventLoopUtilizationUtilization
+          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
+
+  RequestsPerSecondMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ECSAccessLogsGroup
+      FilterPattern: "{ $.requestsPerSecond.dynamic = * }"
+      MetricTransformations:
+        - MetricValue: $.requestsPerSecond.dynamic
+          MetricName: RequestsPerSecond
+          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
+          Unit: Count/Second
+
+  AvgResponseTimeMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ECSAccessLogsGroup
+      FilterPattern: "{ $.avgResponseTime.dynamic = * }"
+      MetricTransformations:
+        - MetricValue: $.avgResponseTime.dynamic
+          MetricName: AvgResponseTime
+          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
+          Unit: Count/Second
+
+  MaxConcurrentConnectionsMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ECSAccessLogsGroup
+      FilterPattern: "{ $.maxConcurrentConnections = * }"
+      MetricTransformations:
+        - MetricValue: $.maxConcurrentConnections
+          MetricName: MaxConcurrentConnections
+          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
+          Unit: Count
 Outputs:
   StackName:
     Description: "CloudFormation stack name"


### PR DESCRIPTION
## Proposed changes

### What changed
Added metrics for the logging for `frontend-vital-signs`

### Why did it change
The log messages provided by the `frontend-vital-signs` package is to help us monitor performance metrics such as average response times and how many requests we get per second. At the moment, that information is just a log message in the CloudWatch logs. This PR creates `MetricFilter`s so that we can visual the data.

## Evidence
Tested each individual metric and it is showing correctly in CloudWatch
![image](https://github.com/user-attachments/assets/a5c9c60b-5ef9-4298-aca1-a852aa69a5df)

### Issue tracking
- [OJ-2759](https://govukverify.atlassian.net/browse/OJ-2759)


[OJ-2759]: https://govukverify.atlassian.net/browse/OJ-2759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ