### PR TITLE
OJ-2752: Add push to main trigger

### DIFF
--- a/.github/workflows/push-test-docker-image.yml
+++ b/.github/workflows/push-test-docker-image.yml
@@ -1,6 +1,9 @@
 name: Push test Docker image
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add push to main trigger

### Why did it change

So that the test image is deployed when a PR is merged to main

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2752](https://govukverify.atlassian.net/browse/OJ-2752)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed




[OJ-2752]: https://govukverify.atlassian.net/browse/OJ-2752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ