### PR TITLE
OJ-2750: Updates to run tests using run-tests.sh

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -68,6 +68,10 @@ Conditions:
     - !Equals [!Ref Environment, production]
     - !Equals [!Ref Environment, build]
 
+  IsDevOrBuild: !Or
+    - !Equals [!Ref Environment, dev]
+    - !Equals [!Ref Environment, build]
+
   DeployAlarms: !Or
     - !Condition IsNotDevelopment
     - !Equals [!Ref DeployAlarmsInDevEnvironment, "true"]
@@ -1560,3 +1564,8 @@ Outputs:
   WebsiteHost:
     Description: "The website host name"
     Value: !Sub https://review-hc.${Environment}.account.gov.uk
+
+  CoreStubURL:
+    Condition: IsDevOrBuild
+    Description: "The core stub URL"
+    Value: !Sub "{{resolve:ssm:/check-hmrc-cri-api/smoke-tests/core-stub-url}}"

--- a/tests/browser/post-merge.Dockerfile
+++ b/tests/browser/post-merge.Dockerfile
@@ -11,4 +11,6 @@ RUN npm install
 
 COPY . ./
 
-CMD ["./run-tests-post-merge.sh"]
+COPY ./run-tests-post-merge.sh /run-tests.sh
+
+CMD ["/run-tests.sh"]

--- a/tests/browser/run-tests-post-merge.sh
+++ b/tests/browser/run-tests-post-merge.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-RELYING_PARTY_URL=$(aws ssm get-parameter --name "/check-hmrc-cri-api/smoke-tests/core-stub-url" --query "Parameter.Value" --output text)
+RELYING_PARTY_URL=$(aws cloudformation describe-stacks --stack-name check-hmrc-cri-front --query "Stacks[0].Outputs[?OutputKey=='CoreStubURL'].OutputValue" --output text)
 WEBSITE_HOST=$(aws cloudformation describe-stacks --stack-name check-hmrc-cri-front --query "Stacks[0].Outputs[?OutputKey=='WebsiteHost'].OutputValue" --output text)
 ENVIRONMENT=$(aws cloudformation describe-stacks --stack-name check-hmrc-cri-front --query "Stacks[0].Outputs[?OutputKey=='Environment'].OutputValue" --output text)
 
@@ -7,5 +7,7 @@ export RELYING_PARTY_URL
 export WEBSITE_HOST
 export ENVIRONMENT
 export GITHUB_ACTIONS=true
+
+cd /tests || exit 1
 
 npm run test:browser -- --tags @post-merge


### PR DESCRIPTION
## Proposed changes

### What and why did it change
* Updated Dockerfile to copy `run-tests-post-merge.sh` into the container as `run-tests.sh`. This is because the pipeline expects the name to be `run-tests.sh` and it could not run without it. 
* Make core stub URL a stack output instead because the PL does not have access to read SSM parameters then also updated `run-tests-post-merge.sh` to fetch core stub URL from stack output instead of SSM

### Issue tracking
- [OJ-2750](https://govukverify.atlassian.net/browse/OJ-2750)


[OJ-2750]: https://govukverify.atlassian.net/browse/OJ-2750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ