### PR TITLE
OJ-2791: Fix env vars for post merge testing

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -68,10 +68,6 @@ Conditions:
     - !Equals [!Ref Environment, production]
     - !Equals [!Ref Environment, build]
 
-  IsDevOrBuild: !Or
-    - !Equals [!Ref Environment, dev]
-    - !Equals [!Ref Environment, build]
-
   DeployAlarms: !Or
     - !Condition IsNotDevelopment
     - !Equals [!Ref DeployAlarmsInDevEnvironment, "true"]
@@ -1556,16 +1552,3 @@ Outputs:
     Export:
       Name: !Sub "${AWS::StackName}-LoadBalancer"
     Value: !Ref LoadBalancer
-
-  Environment:
-    Description: "The environment identifier"
-    Value: !Ref Environment
-
-  WebsiteHost:
-    Description: "The website host name"
-    Value: !Sub https://review-hc.${Environment}.account.gov.uk
-
-  CoreStubURL:
-    Condition: IsDevOrBuild
-    Description: "The core stub URL"
-    Value: !Sub "{{resolve:ssm:/check-hmrc-cri-api/smoke-tests/core-stub-url}}"

--- a/tests/browser/.env.example
+++ b/tests/browser/.env.example
@@ -1,4 +1,4 @@
 USE_LOCAL_API=true
 WEBSITE_HOST=http://localhost:5000
 RELYING_PARTY_URL=http://example.net
-ENV="dev"
+ENVIRONMENT="dev"

--- a/tests/browser/environment-variables.md
+++ b/tests/browser/environment-variables.md
@@ -10,4 +10,4 @@
 | USE_LOCAL_API     | Enable the use of passthrough @mock-api tags into the `client-id`                                                                             | true                  |
 | WEBSITE_HOST      | URL of the website to test against                                                                                                            | http://localhost:5090 |
 | RELYING_PARTY_URL | URL of the relying party, should be `https://user:{password}@cri.core.stubs.account.gov.uk` when using core stub                              | http://example.net    |
-| ENV               | The environment tests are being run against (note only needed for post merge, WEBSITE_HOST should also be updated to reflect the environment) | dev                   |
+| ENVIRONMENT       | The environment tests are being run against (note only needed for post merge, WEBSITE_HOST should also be updated to reflect the environment) | dev                   |

--- a/tests/browser/pages/relying-party.js
+++ b/tests/browser/pages/relying-party.js
@@ -12,7 +12,7 @@ module.exports = class PlaywrightDevPage {
       process.env.RELYING_PARTY_URL || "http://example.net";
     this.baseURL = new URL(websiteHost);
     this.relyingPartyURL = new URL(relyingPartyURL);
-    this.env = process.env.ENV || "dev";
+    this.env = process.env.ENVIRONMENT || "dev";
 
     if (
       process.env.USE_LOCAL_API === "true" ||

--- a/tests/browser/run-tests-post-merge.sh
+++ b/tests/browser/run-tests-post-merge.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
-RELYING_PARTY_URL=$(aws cloudformation describe-stacks --stack-name check-hmrc-cri-front --query "Stacks[0].Outputs[?OutputKey=='CoreStubURL'].OutputValue" --output text)
-WEBSITE_HOST=$(aws cloudformation describe-stacks --stack-name check-hmrc-cri-front --query "Stacks[0].Outputs[?OutputKey=='WebsiteHost'].OutputValue" --output text)
-ENVIRONMENT=$(aws cloudformation describe-stacks --stack-name check-hmrc-cri-front --query "Stacks[0].Outputs[?OutputKey=='Environment'].OutputValue" --output text)
+#!/usr/bin/env bash
+
+ENVIRONMENT=$(aws cloudformation describe-stacks --stack-name check-hmrc-cri-front --query "Stacks[0].Parameters[?ParameterKey=='Environment'].ParameterValue" --output text)
+RELYING_PARTY_URL=$(aws ssm get-parameter --name "/tests/check-hmrc-cri-front/core-stub-url" --query "Parameter.Value" --output text)
+WEBSITE_HOST="https://review-hc.${ENVIRONMENT}.account.gov.uk"
 
 export RELYING_PARTY_URL
 export WEBSITE_HOST

--- a/tests/browser/run-tests-post-merge.sh
+++ b/tests/browser/run-tests-post-merge.sh
@@ -7,6 +7,7 @@ export RELYING_PARTY_URL
 export WEBSITE_HOST
 export ENVIRONMENT
 export GITHUB_ACTIONS=true
+export USE_LOCAL_API=false
 
 cd /tests || exit 1
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Renamed `ENV` to `ENVIRONMENT` because it causes confusion
- Sets `USE_LOCAL_API` in post-merge-run-tests
- Use new SSM param to set `RELYING_PARTY_URL` (see [PR](https://github.com/govuk-one-login/ipv-cri-pipeline-deployment/pull/220))

### Why did it change

For tests to pass

### Screenshots

<img width="708" alt="image" src="https://github.com/user-attachments/assets/ca318fa7-ca32-477e-8539-1e5319c69bcb">

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2791](https://govukverify.atlassian.net/browse/OJ-2791)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [x] Documented in the [README](./blob/main/README.md)
- [x] Added to deployment repository
- [x] Added to local startup repository

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2791]: https://govukverify.atlassian.net/browse/OJ-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ