### PR TITLE
OJ-2924: Invoke Abandon state machine on retry exit

### DIFF
--- a/src/app/check/steps.js
+++ b/src/app/check/steps.js
@@ -27,8 +27,13 @@ module.exports = {
         value: "retryNationalInsurance",
         next: "national-insurance-number",
       },
-      "/oauth2/callback",
+      "abandon",
     ],
+  },
+  "/abandon": {
+    skip: true,
+    controller: AbandonController,
+    next: "/oauth2/callback",
   },
   "/how-continue-national-insurance": {
     prereqs: ["/check"],

--- a/src/app/check/steps.js
+++ b/src/app/check/steps.js
@@ -30,22 +30,21 @@ module.exports = {
       "abandon",
     ],
   },
-  "/abandon": {
-    skip: true,
-    controller: AbandonController,
-    next: "/oauth2/callback",
-  },
   "/how-continue-national-insurance": {
     prereqs: ["/check"],
     fields: ["abandonRadio"],
-    controller: AbandonController,
     next: [
       {
         field: "abandonRadio",
         value: "retryNationalInsurance",
         next: "national-insurance-number",
       },
-      "/oauth2/callback",
+      "abandon",
     ],
+  },
+  "/abandon": {
+    skip: true,
+    controller: AbandonController,
+    next: "/oauth2/callback",
   },
 };

--- a/tests/browser/features/could-not-match-national-insurance.feature
+++ b/tests/browser/features/could-not-match-national-insurance.feature
@@ -1,4 +1,4 @@
-@mock-api:success @retry @post-merge
+@retry @post-merge
 Feature: Could not match national insurance
   Retry on the NINO page
   Background:
@@ -8,19 +8,23 @@ Feature: Could not match national insurance
     And they enter a national insurance number that requires a retry
     When they continue from national insurance number
 
+  @mock-api:success
   Scenario: Display could not match national insurance number page
     Then they should see the could not match national insurance number page
 
+  @mock-api:success
   Scenario: Validation on could not match national insurance number page
     When they click continue could not match national insurance number
     Then they should see could not match national insurance validation messages
 
+  @mock-api:success
   Scenario: choose to retry entering details on the national insurance number page
     When they choose to retry entering national insurance number
     When they click continue could not match national insurance number
     Then they should see the national insurance number page
 
+  @mock-api:access-denied
   Scenario: Stop answering questions
     When they choose to not retry entering national insurance number
     When they click continue could not match national insurance number
-    Then they should be redirected
+    Then they should be redirected to access_denied

--- a/tests/browser/step_definitions/could-not-match-national-insurance.js
+++ b/tests/browser/step_definitions/could-not-match-national-insurance.js
@@ -3,7 +3,7 @@ const {
   CouldNotMatchNationalInsurancePage,
   RelyingPartyPage,
 } = require("../pages");
-const { expect } = require("chai");
+const { expect, assert } = require("chai");
 
 When(
   "they click continue could not match national insurance number",
@@ -32,9 +32,11 @@ When(
   }
 );
 
-Then("they should be redirected", function () {
+Then("they should be redirected to access_denied", function () {
   const rpPage = new RelyingPartyPage(this.page);
   expect(rpPage.isRelyingPartyServer()).to.be.true;
+  const { searchParams } = new URL(rpPage.page.url());
+  assert.equal(searchParams.get("error"), "access_denied");
 });
 
 Then(

--- a/tests/imposter/private-api-config.yaml
+++ b/tests/imposter/private-api-config.yaml
@@ -137,6 +137,19 @@ resources:
   - method: POST
     path: /check
     requestHeaders:
+      session-id: "access-denied"
+    requestBody:
+      allOf:
+        - jsonPath: $.nino
+          value: "EE123456A"
+    response:
+      statusCode: 422
+      content: |
+        {}
+
+  - method: POST
+    path: /check
+    requestHeaders:
       session-id: "check-error"
     response:
       statusCode: 500


### PR DESCRIPTION
## Proposed changes

### What changed

Added a step/route to use the abandon controller prior to routing to the callback.

### Why did it change

Emit the IPV_HMRC_RECORD_CHECK_CRI_ABANDONED event when a user selects the "Try another way to prove your identity" option on the retry screen.

Also, When a user went to the 'how-continue-national-insurance' page, even if they selected 'Enter national insurance number ...', when they clicked Continue the abandon state machine would be invoked. Only abandon if the user selects 'Try another way...'

### Issue tracking

- [OJ-2924](https://govukverify.atlassian.net/browse/OJ-2924)

[OJ-2924]: https://govukverify.atlassian.net/browse/OJ-2924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ