### PR TITLE
build: bump govuk-frontend to version 4.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "express": "4.21.1",
         "express-async-errors": "3.1.1",
         "express-session": "1.18.1",
-        "govuk-frontend": "4.8.0",
+        "govuk-frontend": "4.9.0",
         "hmpo-app": "3.0.1",
         "hmpo-components": "6.5.0",
         "hmpo-form-wizard": "13.0.0",
@@ -5782,9 +5782,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
-      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.9.0.tgz",
+      "integrity": "sha512-zfX+GBUKpWBeV6JwCIawEuI8VRWlskH8Ok8aNUjKOvzo3zIaNbcrv4IOwgy+oSnMoGh67Eeh+vb7+9GFxN2fNg==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "express": "4.21.1",
     "express-async-errors": "3.1.1",
     "express-session": "1.18.1",
-    "govuk-frontend": "4.8.0",
+    "govuk-frontend": "4.9.0",
     "hmpo-app": "3.0.1",
     "hmpo-components": "6.5.0",
     "hmpo-form-wizard": "13.0.0",


### PR DESCRIPTION
## Proposed changes

### What changed

Bump govuk-frontend to version 4.9.0

### Why did it change
There have been changes to crown logo.

### Issue tracking
- [OJ-2914](https://govukverify.atlassian.net/browse/OJ-2914)


[OJ-2914]: https://govukverify.atlassian.net/browse/OJ-2914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ