### PR TITLE
Bug fix: Fix tests failing in the pipeline

### DIFF
--- a/tests/browser/pages/relying-party.js
+++ b/tests/browser/pages/relying-party.js
@@ -25,7 +25,7 @@ module.exports = class PlaywrightDevPage {
 
   async goto(rowNumber) {
     if (process.env.USE_LOCAL_API === "false") {
-      this.startingURL = await this.getStartingURLForStub1(rowNumber);
+      this.startingURL = await this.getStartingURLForStub(rowNumber);
     }
 
     await this.page.goto(this.startingURL.toString());


### PR DESCRIPTION
## Proposed changes

### What changed

Change method call `getStartingURLForStub1` to `getStartingURLForStub`.

### Why did it change

Tests pass locally, but fail when ran through the pipeline. Looks to be a typo in the code that only fails when USE_LOCAL_API is false.

Looks to have been a bug added in: https://github.com/govuk-one-login/ipv-cri-check-hmrc-front/pull/308/files#diff-7acb2c3a3f5f5c67524cfafe4c7994bff12390a6bdfde7f659b3859cb0bbee74R28

### Error Screenshot

![image](https://github.com/user-attachments/assets/7d5ee480-323d-471a-8017-68aeb3d1d389)
