### PR TITLE
Turn off UA as it is no longer being used

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -432,7 +432,7 @@ Resources:
             - Name: ANALYTICS_DATA_SENSITIVE
               Value: "false"
             - Name: UA_ENABLED
-              Value: true
+              Value: false
             - Name: ANALYTICS_COOKIE_DOMAIN
               Value:
                 !If [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Turn off UA as it is no longer being used.

There will be subsequent tickets to deprecate but this is just to turn off as it causes a console error with new versions of the `@govuk-one-login/frontend-analytics` package.
