### PR TITLE
feat: handle http 200 with retry

### DIFF
--- a/src/app/check/controllers/national-insurance-number.js
+++ b/src/app/check/controllers/national-insurance-number.js
@@ -42,6 +42,10 @@ class NationalInsuranceNumberController extends BaseController {
           req.session.redirectToRetry = true;
         }
 
+        if (response.status === 200 && response.data.requestRetry === true) {
+          req.session.redirectToRetry = true;
+        }
+
         callback();
       } catch (err) {
         if (err) {

--- a/tests/imposter/private-api-config.yaml
+++ b/tests/imposter/private-api-config.yaml
@@ -105,7 +105,7 @@ resources:
     response:
       statusCode: 200
       content: |
-        {}
+        {"requestRetry":false}
 
   - method: POST
     path: /check
@@ -119,7 +119,7 @@ resources:
     response:
       statusCode: 200
       content: |
-        {}
+        {"requestRetry":false}
 
   - method: POST
     path: /check
@@ -130,9 +130,9 @@ resources:
         - jsonPath: $.nino
           value: "EE123456A"
     response:
-      statusCode: 422
+      statusCode: 200
       content: |
-        {}
+        {"requestRetry":true}
 
   - method: POST
     path: /check
@@ -143,9 +143,9 @@ resources:
         - jsonPath: $.nino
           value: "EE123456A"
     response:
-      statusCode: 422
+      statusCode: 200
       content: |
-        {}
+        {"requestRetry":true}
 
   - method: POST
     path: /check

--- a/tests/unit/src/app/check/controllers/national-insurance-number.test.js
+++ b/tests/unit/src/app/check/controllers/national-insurance-number.test.js
@@ -76,6 +76,37 @@ describe("national insurance number", () => {
       });
     });
 
+    describe("with 200 status and requestRetry", () => {
+      it('should set "showRetryErrorSummary" to true', async () => {
+        req.axios.post = jest
+          .fn()
+          .mockResolvedValue({ status: 200, data: { requestRetry: true } });
+
+        await controller.saveValues(req, res, next);
+
+        expect(req.session.redirectToRetry).toBe(true);
+        expect(controller.hasRedirectToRetryShowing(req)).toBe(true);
+      });
+      it('should not set "showRetryErrorSummary" to true', async () => {
+        req.axios.post = jest
+          .fn()
+          .mockResolvedValue({ status: 200, data: { requestRetry: false } });
+
+        await controller.saveValues(req, res, next);
+
+        expect(req.session.redirectToRetry).toBe(false);
+        expect(controller.hasRedirectToRetryShowing(req)).toBe(false);
+      });
+      it('should not set "showRetryErrorSummary" to true when missing requestRetry', async () => {
+        req.axios.post = jest.fn().mockResolvedValue({ status: 200 });
+
+        await controller.saveValues(req, res, next);
+
+        expect(req.session.redirectToRetry).toBe(false);
+        expect(controller.hasRedirectToRetryShowing(req)).toBe(false);
+      });
+    });
+
     describe("on API failure", () => {
       it("should call next with error", async () => {
         const error = new Error("Async error message");


### PR DESCRIPTION
## Proposed changes

### What changed
Added support for http 200 with requestRetry

### Why did it change
BE now returns http 200 with a body requestRetry: true

### Issue tracking
- [OJ-2921](https://govukverify.atlassian.net/browse/OJ-2921)


[OJ-2921]: https://govukverify.atlassian.net/browse/OJ-2921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ