### PR TITLE
feat: remove 422 status check

### DIFF
--- a/src/app/check/controllers/national-insurance-number.js
+++ b/src/app/check/controllers/national-insurance-number.js
@@ -11,7 +11,7 @@ const {
 
 /* istanbul ignore next @preserve */
 const validateStatus = (status) => {
-  return (status >= 200 && status < 300) || status === 422;
+  return status >= 200 && status < 300;
 };
 
 class NationalInsuranceNumberController extends BaseController {
@@ -37,10 +37,6 @@ class NationalInsuranceNumberController extends BaseController {
             validateStatus,
           }
         );
-
-        if (response.status === 422) {
-          req.session.redirectToRetry = true;
-        }
 
         if (response.status === 200 && response.data.requestRetry === true) {
           req.session.redirectToRetry = true;

--- a/tests/imposter/private-api.yaml
+++ b/tests/imposter/private-api.yaml
@@ -124,8 +124,6 @@ paths:
           description: OK
         "400":
           description: Bad Request
-        "422":
-          description: Unprocessable Content
         "500":
           description: Internal Server Error
       x-amazon-apigateway-integration:

--- a/tests/unit/src/app/check/controllers/national-insurance-number.test.js
+++ b/tests/unit/src/app/check/controllers/national-insurance-number.test.js
@@ -65,17 +65,6 @@ describe("national insurance number", () => {
       });
     });
 
-    describe("with 422 status", () => {
-      it('should set "showRetryErrorSummary" to true', async () => {
-        req.axios.post = jest.fn().mockResolvedValue({ status: 422 });
-
-        await controller.saveValues(req, res, next);
-
-        expect(req.session.redirectToRetry).toBeTruthy();
-        expect(controller.hasRedirectToRetryShowing(req)).toBeTruthy();
-      });
-    });
-
     describe("with 200 status and requestRetry", () => {
       it('should set "showRetryErrorSummary" to true', async () => {
         req.axios.post = jest


### PR DESCRIPTION
## Proposed changes

### What changed
Removed http 422 check

### Why did it change
The API now returns a HTTP 200 with requestRetry in the body so the 422 check is redundant.

### Issue tracking
- [OJ-2921](https://govukverify.atlassian.net/browse/OJ-2921)


[OJ-2921]: https://govukverify.atlassian.net/browse/OJ-2921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ