### PR TITLE
OJ-2864: Add overload-protection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,11 @@
         "hmpo-form-wizard": "13.0.0",
         "hmpo-i18n": "6.0.1",
         "hmpo-logger": "7.0.1",
-        "nunjucks": "3.2.4"
+        "nunjucks": "3.2.4",
+        "overload-protection": "1.2.3"
       },
       "devDependencies": {
+        "@types/overload-protection": "1.2.4",
         "chai": "4.4.1",
         "chai-as-promised": "7.1.1",
         "copyfiles": "2.4.1",
@@ -2999,6 +3001,12 @@
       "version": "20.6.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.2.tgz",
       "integrity": "sha512-Y+/1vGBHV/cYk6OI1Na/LHzwnlNCAfU3ZNGrc1LdRe/LAIbdDPTTv/HU3M7yXN448aTVDq3eKRm2cg7iKLb8gw=="
+    },
+    "node_modules/@types/overload-protection": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/overload-protection/-/overload-protection-1.2.4.tgz",
+      "integrity": "sha512-zbKBN5pZXwF4yiXUeF0Cng4Y+sqqTWVeyi++uR6Ycd8oThOGPBMEdHyX81Z1vU4wojh9+NDS0y6JX7nM6ylBCw==",
+      "dev": true
     },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
@@ -7530,6 +7538,14 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/loopbench": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/loopbench/-/loopbench-1.2.0.tgz",
+      "integrity": "sha512-ft2PmuZnDw+DJQfT5mpEWudEBRzlpImh7mU7OcPGmefsKlW8Ck0U6nrCCdcwYF+z9zc0SVBzGZA1F1gUfHZuJw==",
+      "dependencies": {
+        "xtend": "^4.0.1"
+      }
+    },
     "node_modules/loupe": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
@@ -8075,6 +8091,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/overload-protection": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/overload-protection/-/overload-protection-1.2.3.tgz",
+      "integrity": "sha512-b7XZbmhujnqNoK0Z6NPzA/nhfQnE08ZTHSzzjTMwegb5N9oBAAApx3f9u2R/f3VGaACTQj6QJnGUfX1oFttqfg==",
+      "dependencies": {
+        "loopbench": "^1.2.0"
       }
     },
     "node_modules/p-cancelable": {
@@ -10036,7 +10060,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4"
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "overload-protection": "1.2.3",
     "@aws-sdk/client-dynamodb": "3.668.0",
     "@govuk-one-login/di-ipv-cri-common-express": "8.1.0",
     "@govuk-one-login/frontend-analytics": "3.0.0",
@@ -42,6 +43,7 @@
     "nunjucks": "3.2.4"
   },
   "devDependencies": {
+    "@types/overload-protection": "1.2.4",
     "chai": "4.4.1",
     "chai-as-promised": "7.1.1",
     "copyfiles": "2.4.1",

--- a/src/app.js
+++ b/src/app.js
@@ -20,6 +20,8 @@ const {
 
 const addLanguageParam = require("@govuk-one-login/frontend-language-toggle/build/cjs/language-param-setter.cjs");
 
+const protect = require("overload-protection");
+
 const {
   API,
   APP,
@@ -110,6 +112,19 @@ const { app, router } = setup({
       ],
     });
     app.use(setHeaders);
+
+    app.use(
+      protect("express", {
+        production: process.env.NODE_ENV === "production",
+        clientRetrySecs: 1,
+        sampleInterval: 5,
+        maxEventLoopDelay: 52,
+        maxHeapUsedBytes: 0,
+        maxRssBytes: 0,
+        errorPropagationMode: false,
+        logging: "error",
+      })
+    );
   },
   dev: true,
 });


### PR DESCRIPTION
## Proposed changes

### What changed
Added overload-protection library to app.js

### Why did it change
To prevent node from accepting too many connections and putting itself into a blocking state.

### Issue tracking
- [OJ-2864](https://govukverify.atlassian.net/browse/OJ-2864)



[OJ-2864]: https://govukverify.atlassian.net/browse/OJ-2864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ