### PR TITLE
OJ-2872: And new alarm definition for 80%  5xx errors fe api-gateway

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -875,12 +875,12 @@ Resources:
         SSEEnabled: true
         SSEType: KMS
 
-  FE5XXErrorAlarm:
+  FE5XXErrorCriticalAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: DeployAlarms
     Properties:
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-FE5XXErrorAlarm"
-      AlarmDescription: !Sub "Threshold exceeds 10% with a minimum of 150 invocations and a minimum of 5 errors in 5 out of the last 5 minutes. ${SupportManualURL}"
+      AlarmName: !Sub "${AWS::StackName}-${Environment}-FE5XXErrorCriticalAlarm"
+      AlarmDescription: !Sub "Threshold exceeds 80% with a minimum of at least 5 invocations in 2 out of the last 5 evaluation periods of (15mins each). ${SupportManualURL}"
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
@@ -888,18 +888,20 @@ Resources:
       OKActions:
         - !ImportValue core-infrastructure-AlarmTopic
         - !ImportValue platform-alarm-critical-alert-topic
-      InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 5
-      DatapointsToAlarm: 5
-      Threshold: 1
+      DatapointsToAlarm: 2
+      Threshold: 80
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
       Metrics:
         - Id: errorThreshold
           Label: errorThreshold
           ReturnData: true
-          Expression: IF(invocations<150 || error<5,0,errorPercentage)
+          Expression: IF(invocations >= 5, errorPercentage, 0)
+        - Id: errorPercentage
+          Label: errorPercentage
+          ReturnData: false
+          Expression: (error / invocations) * 100
         - Id: invocations
           ReturnData: false
           MetricStat:
@@ -909,7 +911,7 @@ Resources:
               Dimensions:
                 - Name: ApiId
                   Value: !Ref ApiGwHttpEndpoint
-            Period: 60
+            Period: 900
             Stat: Sum
         - Id: error
           ReturnData: false
@@ -920,12 +922,8 @@ Resources:
               Dimensions:
                 - Name: ApiId
                   Value: !Ref ApiGwHttpEndpoint
-            Period: 60
+            Period: 900
             Stat: Sum
-        - Id: errorPercentage
-          Label: errorPercentage
-          ReturnData: false
-          Expression: (error/invocations) * 100
 
   FE4XXErrorAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -1259,7 +1257,7 @@ Resources:
                 "properties": {
                   "title": "F2F Front 5XX Error Alarm - ${AWS::StackName}",
                   "annotations": {
-                    "alarms": ["${FE5XXErrorAlarm.Arn}"]
+                    "alarms": ["${FE5XXErrorCriticalAlarm.Arn}"]
                   },
                   "view": "timeSeries",
                   "stacked": false


### PR DESCRIPTION
Using the minium invocation count as baseline 300 invocations / day => 1440 minutes / day is approximately about 0.21 invocations per minute. The period has be adjusted to allow for enough activity 15 mins i.e 900 secs

Traffic last [90days](https://gds.splunkcloud.com/en-GB/app/gds-050-digital-Identity/search?dispatch.sample_ratio=1&display.page.search.mode=smart&workload_pool=standard_perf&q=search%20index%3D%22gds_di_production%22%20source%3D%22*check-hmrc-cri-front-*%22%20sourcetype%3D%22aws%3Acloudwatchlogs%3Aapi-access-*%22%20di_account_name_enriched%3D%22di-ipv-cri-check-hmrc-prod%22%20%0A%7C%20timechart%20span%3D1d%20count%20as%20requests&earliest=-90d%40d&latest=now&display.page.search.tab=visualizations&display.general.type=visualizations&sid=1734449016.69326)

![image](https://github.com/user-attachments/assets/58865500-1c8d-45d5-a1ec-a1dbd07e4b53)
```
index="gds_di_production" source="*check-hmrc-cri-front-*" sourcetype="aws:cloudwatchlogs:api-access-*" di_account_name_enriched="di-ipv-cri-check-hmrc-prod" 
| timechart span=1d count as requests
```

- [OJ-2872](https://govukverify.atlassian.net/browse/OJ-2872)


- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2872]: https://govukverify.atlassian.net/browse/OJ-2872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ