### PR TITLE
OJ-2942: Remove MaxContainerCount Stack parameter

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -29,11 +29,6 @@ Parameters:
     Type: String
     Default: "none"
 
-  MaxContainerCount:
-    Description: Maximum number of FE node/express container tasks to allow autoscaling to reach
-    Type: Number
-    Default: 12
-
   SupportManualURL:
     Type: String
     Default: "https://team-manual.account.gov.uk/teams/CRI-Orange-team/supporting-cri-orange/hmrc-nino-runbook/#frontend-api-alarms"
@@ -1192,7 +1187,7 @@ Resources:
       Dimensions: []
       EvaluationPeriods: 5
       DatapointsToAlarm: 5
-      Threshold: !Ref MaxContainerCount
+      Threshold: 13
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
       Metrics:


### PR DESCRIPTION
## Proposed changes

### What changed

The stack parameters are difficult to change, there is no reason for MaxContainerCount to be one and it needs increasing. Removing the param and hardcoding the alarm threshold to 13.

### Why did it change

So FEHighContainerTaskCountWarning does not alarm when we deploy a new FE update to Prod & Build.

### Issue tracking

- [OJ-2942](https://govukverify.atlassian.net/browse/OJ-2942)


[OJ-2942]: https://govukverify.atlassian.net/browse/OJ-2942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ