### PR TITLE
OJ-2975: Update serviceName to trigger common express condition

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -3,7 +3,7 @@ buttons:
   next: "Parhau"
   cancel: "Canslo"
 govuk:
-  serviceName: "Profi pwy ydych chi"
+  serviceName: " "
   backLink: "Yn ôl"
   errorSummaryTitle: "Mae problem"
   error: "Gwall"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -3,7 +3,7 @@ buttons:
   next: Continue
   cancel: Cancel
 govuk:
-  serviceName: Prove your identity
+  serviceName: " "
   backLink: Back
   errorSummaryTitle: There is a problem
   error: Error


### PR DESCRIPTION
## Proposed changes

### What changed
- Updated `serviceName` to " " for both English and Welsh for the common express condition to trigger 

https://github.com/user-attachments/assets/8ed45b7e-2fd5-4147-8cab-39a68df37936


### Why did it change

Based on the accessibility testing documented [here](https://govukverify.atlassian.net/wiki/spaces/A/pages/4461756473/Page+titles+in+GOV.UK+One+Login)

### Issue tracking

- [OJ-2975](https://govukverify.atlassian.net/browse/OJ-2975)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2975]: https://govukverify.atlassian.net/browse/OJ-2975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ