### PR TITLE
OJ-2946: ECS task healthcheck

### DIFF
--- a/.github/workflows/post-merge-to-dev.yml
+++ b/.github/workflows/post-merge-to-dev.yml
@@ -37,8 +37,6 @@ jobs:
           artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_BUCKET_NAME }}
           container-sign-kms-key-arn: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
           template-file: deploy/template.yaml
-          working-directory: .
-          docker-build-path: .
           dockerfile: dev.Dockerfile
           role-to-assume-arn: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
           ecr-repo-name: ${{ secrets.DEV_ECR_NAME_FRONT }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,14 @@
-FROM node:22.4.1-alpine3.19@sha256:67225d40d3fb36314e392846effda04b95c973bf52e44ea064a8e0015c83056e AS builder
+ARG NODE_SHA=sha256:67225d40d3fb36314e392846effda04b95c973bf52e44ea064a8e0015c83056e
+FROM node:22.4.1-alpine3.19@${NODE_SHA} AS builder
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci
-
 COPY /src ./src
-RUN npm run build
 
-RUN npm prune
+RUN npm ci && npm run build && npm prune
 
-FROM node:22.4.1-alpine3.19@sha256:67225d40d3fb36314e392846effda04b95c973bf52e44ea064a8e0015c83056e AS final
-
-RUN ["apk", "--no-cache", "upgrade"]
-RUN ["apk", "add", "--no-cache", "tini"]
+FROM node:22.4.1-alpine3.19@${NODE_SHA} AS final
+RUN apk --no-cache upgrade && apk add --no-cache tini curl
 
 WORKDIR /app
 
@@ -25,10 +21,13 @@ COPY --from=builder /app/src ./src
 
 # Add in dynatrace layer
 COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs / /
-ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+ENV LD_PRELOAD=/opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
-ENV PORT 8080
+ENV PORT=8080
 EXPOSE $PORT
+
+HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:$PORT/healthcheck || exit 1
 
 ENTRYPOINT ["tini", "--"]
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -474,6 +474,14 @@ Resources:
               awslogs-group: !Ref ECSAccessLogsGroup
               awslogs-region: !Sub ${AWS::Region}
               awslogs-stream-prefix: !Sub ${AWS::StackName}-${Environment}
+          HealthCheck:
+            Command:
+              - CMD-SHELL
+              - curl -f http://localhost:8080/healthcheck || exit 1 # If a HealthCheck returns a non-zero exit code, then it's considered unhealthy.
+            Interval: 10
+            Timeout: 2
+            Retries: 10 # This ensures that just one healthcheck failure won't cause the container to be drained and replaced.
+            StartPeriod: 0
       Cpu: "512"
       ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
       Memory: "1024"

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,7 +1,9 @@
+ARG DYNATRACE_SOURCE=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs
 ARG NODE_SHA=sha256:56e8282f4392fb96c877babc93b3829e46b79c6fbcd48c92de578febffc80587
-ARG TARGET_PLATFORM=linux/arm64
 
-FROM --platform=${TARGET_PLATFORM} arm64v8/node@${NODE_SHA} AS builder
+FROM ${DYNATRACE_SOURCE} AS dynatrace
+FROM arm64v8/node@${NODE_SHA} AS builder
+
 WORKDIR /app
 
 COPY package.json package-lock.json ./
@@ -9,11 +11,13 @@ COPY /src ./src
 
 RUN npm ci && npm run build && npm prune
 
-FROM --platform=${TARGET_PLATFORM} arm64v8/node@${NODE_SHA} AS final
+FROM arm64v8/node@${NODE_SHA} AS final
 
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends curl tini \
-  && rm -rf /var/lib/apt/lists/*
+RUN <<COMMANDS
+  apt-get update -y
+  apt-get install -y --no-install-recommends curl tini
+  apt-get clean
+COMMANDS
 
 WORKDIR /app
 
@@ -25,7 +29,7 @@ COPY --from=builder /app/package-lock.json ./
 COPY --from=builder /app/src ./src
 
 # Add in dynatrace layer
-COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs / /
+COPY --from=dynatrace / /
 ENV LD_PRELOAD=/opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
 ENV PORT=8080
@@ -35,5 +39,4 @@ HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:$PORT/healthcheck || exit 1
 
 ENTRYPOINT ["tini", "--"]
-
 CMD ["npm", "start"]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,5 +1,5 @@
 ARG DYNATRACE_SOURCE=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs
-ARG NODE_SHA=sha256:56e8282f4392fb96c877babc93b3829e46b79c6fbcd48c92de578febffc80587
+ARG NODE_SHA=sha256:9ed7b5265e6af2910e66e097057b38533cf669ee4fa6d9d574c01135bd0c6b6a
 
 FROM ${DYNATRACE_SOURCE} AS dynatrace
 FROM arm64v8/node@${NODE_SHA} AS builder

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -10,6 +10,9 @@ RUN npm ci
 COPY . ./
 RUN npm run build
 
+HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:$PORT/healthcheck || exit 1
+
 CMD npm run dev
 
 EXPOSE $PORT

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "di-ipv-cri-check-hmrc-front",
+      "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.668.0",
         "@govuk-one-login/di-ipv-cri-common-express": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "di-ipv-cri-check-hmrc-front",
   "description": "Frontend for the Check HMRC Credential Issuer",
+  "license": "MIT",
   "scripts": {
     "start": "node src/app.js",
     "dev": "NODE_ENV=development nodemon src/app.js",


### PR DESCRIPTION
## Proposed changes

Currently load balancers are configured to call healthcheck endpoints to ensure that the target is healthy and ready to receive traffic, but also we need to implement configuration to for the task definition.
So as to enable it replace unhealthy tasks before the point of them being requested by the load balancer.

Below is healthcheck inside the dockerfile

![image](https://github.com/user-attachments/assets/dc465731-0951-4b2a-8343-76337619c414)


- [OJ-2946](https://govukverify.atlassian.net/browse/OJ-2946)

[OJ-2946]: https://govukverify.atlassian.net/browse/OJ-2946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ