### PR TITLE
IPS-1332: Predictive scaling for ECS in forecast mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         exclude: package-lock.json
@@ -10,7 +10,7 @@ repos:
       - id: no-commit-to-branch
       - id: trailing-whitespace
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v0.83.8
+    rev: v1.22.7
     hooks:
       - id: cfn-lint
         files: .template\.ya?ml$

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -120,5 +120,5 @@
     }
   ],
   "results": {},
-  "generated_at": "2024-01-17T16:32:24Z"
+  "generated_at": "2025-01-24T15:57:05Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -51,17 +51,10 @@ Parameters:
     # Allowed values: See https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html
 
 Conditions:
-  IsNotDevelopment: !Or
-    - !Equals [!Ref Environment, build]
-    - !Equals [!Ref Environment, staging]
-    - !Equals [!Ref Environment, integration]
-    - !Equals [!Ref Environment, production]
+  IsNotDevelopment: !Not
+    - !Equals [!Ref Environment, dev]
 
   IsProduction: !Equals [!Ref Environment, production]
-
-  IsProductionOrBuild: !Or
-    - !Equals [!Ref Environment, production]
-    - !Equals [!Ref Environment, build]
 
   DeployAlarms: !Or
     - !Condition IsNotDevelopment
@@ -80,14 +73,24 @@ Mappings:
   EnvironmentConfiguration:
     dev:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      minECSCount: 1
+      maxECSCount: 4
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      minECSCount: 6
+      maxECSCount: 60
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      minECSCount: 2
+      maxECSCount: 4
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      minECSCount: 2
+      maxECSCount: 4
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
+      minECSCount: 6
+      maxECSCount: 60
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
     eu-west-2:
@@ -291,7 +294,12 @@ Resources:
           Value: !Sub "${Environment}"
 
   EcsService:
-    Type: "AWS::ECS::Service"
+    Type: AWS::ECS::Service
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3056 # We want to remove load balancers if we are doing canary deployments
     Properties:
       Cluster: !Ref EcsCluster
       DeploymentController:
@@ -730,32 +738,42 @@ Resources:
   # ECS Autoscaling
 
   ECSAutoScalingTarget:
-    Condition: IsProductionOrBuild
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
-      MaxCapacity: 60
-      MinCapacity: 6
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref EcsCluster
-          - !GetAtt EcsService.Name
+      MinCapacity:
+        !FindInMap [EnvironmentConfiguration, !Ref Environment, minECSCount]
+      MaxCapacity:
+        !FindInMap [EnvironmentConfiguration, !Ref Environment, maxECSCount]
+      ResourceId: !Sub service/${EcsCluster}/${EcsService.Name}
       RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService"
       ScalableDimension: ecs:service:DesiredCount
       ServiceNamespace: ecs
 
+  ECSPredictiveScalingPolicy:
+    DependsOn: ECSAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: ECSPredictiveScalingPolicy
+      PolicyType: PredictiveScaling
+      ResourceId: !Sub service/${EcsCluster}/${EcsService.Name}
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      PredictiveScalingPolicyConfiguration:
+        MaxCapacityBreachBehavior: HonorMaxCapacity
+        MetricSpecifications:
+          - PredefinedMetricPairSpecification:
+              PredefinedMetricType: ECSServiceCPUUtilization
+            TargetValue: 60
+        Mode: ForecastOnly
+        SchedulingBufferTime: 600
+
   StepScaleInPolicy:
-    Condition: IsProductionOrBuild
     DependsOn: ECSAutoScalingTarget
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
       PolicyName: StepScalingInPolicy
       PolicyType: StepScaling
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref EcsCluster
-          - !GetAtt EcsService.Name
+      ResourceId: !Sub service/${EcsCluster}/${EcsService.Name}
       ScalableDimension: ecs:service:DesiredCount
       ServiceNamespace: ecs
       StepScalingPolicyConfiguration:
@@ -769,17 +787,12 @@ Resources:
             ScalingAdjustment: -50
 
   StepScaleOutPolicy:
-    Condition: IsProductionOrBuild
     DependsOn: ECSAutoScalingTarget
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
       PolicyName: StepScalingOutPolicy
       PolicyType: StepScaling
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref EcsCluster
-          - !GetAtt EcsService.Name
+      ResourceId: !Sub service/${EcsCluster}/${EcsService.Name}
       ScalableDimension: ecs:service:DesiredCount
       ServiceNamespace: ecs
       StepScalingPolicyConfiguration:
@@ -799,7 +812,6 @@ Resources:
             ScalingAdjustment: 500
 
   StepScaleOutAlarm:
-    Condition: IsProductionOrBuild
     DependsOn: ECSAutoScalingTarget
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -823,7 +835,6 @@ Resources:
       Threshold: "60"
 
   StepScaleInAlarm:
-    Condition: IsProductionOrBuild
     DependsOn: ECSAutoScalingTarget
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -928,7 +939,6 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
       Threshold: 5
@@ -978,7 +988,6 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
       Threshold: 1000
@@ -1024,7 +1033,6 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
       Threshold: 2500
@@ -1147,7 +1155,6 @@ Resources:
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
       Threshold: 1
@@ -1178,7 +1185,6 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 5
       DatapointsToAlarm: 5
       Threshold: 13
@@ -1211,7 +1217,6 @@ Resources:
       OKActions:
         - !ImportValue platform-alarm-critical-alert-topic
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
       Threshold: 0


### PR DESCRIPTION
### What changed

- Added capacity mapping for ECS task counts 
- Removed condition on creating auto scaling policy so it applies to all envs
- This adds a new Predicitive scaling policy which will scale the number of instances based on some AWS created  algorithm using the previous traffic patterns as input. See this for more information:
https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-predictive-scaling.html
- The policy is in `Forecast Mode` only so we can understand its behaviour. The predictive scaling policy will not take any action, see below in dev:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/fb977a51-df5c-4c56-bb31-52b94b9d5cdb" />

- Update pre-commit config and fixed linting issue:
```
E3020 'Dimensions' should not be included with 'Metrics'
deploy/template.yaml:1225:7
```

### Why did it change

- Cost saving
- To be more Environmentally friendly
- Reliability for users

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-1284
