### PR TITLE
feat: increase cpu to 2048 and memory to 4096

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -490,7 +490,7 @@ Resources:
             Timeout: 2
             Retries: 10 # This ensures that just one healthcheck failure won't cause the container to be drained and replaced.
             StartPeriod: 0
-      Cpu: "512"
+      Cpu: "2048"
       ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
       Memory: "1024"
       NetworkMode: awsvpc

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -492,7 +492,7 @@ Resources:
             StartPeriod: 0
       Cpu: "2048"
       ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
-      Memory: "1024"
+      Memory: "4096"
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE


### PR DESCRIPTION
## Proposed changes

### What changed
CPU increased to 2048 and memory to 4096

### Why did it change
Due to the way that nodeJS uses the eventLoop, the performance of the container performs better if there is a second CPU able to offload some of async threads.

### Issue tracking
- [OJ-3041](https://govukverify.atlassian.net/browse/OJ-3041)


[OJ-3041]: https://govukverify.atlassian.net/browse/OJ-3041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ