### PR TITLE
OJ-2873: Set unique DT_HOST_ID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,6 @@ EXPOSE $PORT
 HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:$PORT/healthcheck || exit 1
 
-ENTRYPOINT ["tini", "--"]
+ENTRYPOINT ["sh", "-c", "export DT_HOST_ID=CHECK-HMRC-CRI-FRONT-$RANDOM && tini npm start"]
 
 CMD ["npm", "start"]


### PR DESCRIPTION
## Proposed changes

### What changed

Create unique DT_HOST_ID value for different containers.

### Why did it change

Having unique DT_HOST_ID values allows for monitoring of different containers.

Note: DT = Dynatrace

### Issue tracking

- [OJ-2873](https://govukverify.atlassian.net/browse/OJ-2873)


[OJ-2873]: https://govukverify.atlassian.net/browse/OJ-2873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ