### PR TITLE
IPS-1436 re-associate web ACL

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -733,7 +733,6 @@ Resources:
       TreatMissingData: notBreaching
 
   CloudFrontWAFv2ACLAssociation:
-    Condition: IsNotDevelopment
     Type: AWS::WAFv2::WebACLAssociation
     Properties:
       ResourceArn: !Ref LoadBalancer


### PR DESCRIPTION
## Proposed changes

### What changed

Load balancer updates for the FMS firewall - Re-enable WAF association in dev

### Why did it change

This is still required

### Issue tracking

- [IPS-1436](https://govukverify.atlassian.net/browse/IPS-1436)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

Application happening today

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1436]: https://govukverify.atlassian.net/browse/IPS-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ