### PR TITLE
OJ-3007: Amend Nino error message

### DIFF
--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@0739d7e7a19bae3177cf851ae51944bb4dd53565 #30th Jan 2024
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@4616241694c035be4ea4a10fc0fe6521c0f079f8
         with:
           coverage-artifact: ${{ needs.unit-tests.outputs.coverage-artifact }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/app/check/fields.js
+++ b/src/app/check/fields.js
@@ -13,11 +13,15 @@ module.exports = {
       },
       {
         type: "nino",
-        fn: isValidNino,
+        fn: (value) => {
+          return isValidNino(value);
+        },
       },
       {
         type: "invalidLetter",
-        fn: invalidCharacters,
+        fn: (value) => {
+          return invalidCharacters(value);
+        },
       },
     ],
   },

--- a/src/app/check/fields.js
+++ b/src/app/check/fields.js
@@ -1,4 +1,4 @@
-const { isValidNino } = require("../../lib/validator");
+const { isValidNino, invalidCharacters } = require("../../lib/validator");
 
 module.exports = {
   nationalInsuranceNumber: {
@@ -14,6 +14,10 @@ module.exports = {
       {
         type: "nino",
         fn: isValidNino,
+      },
+      {
+        type: "invalidLetter",
+        fn: invalidCharacters,
       },
     ],
   },

--- a/src/app/check/fields.js
+++ b/src/app/check/fields.js
@@ -13,15 +13,11 @@ module.exports = {
       },
       {
         type: "nino",
-        fn: (value) => {
-          return isValidNino(value);
-        },
+        fn: isValidNino,
       },
       {
         type: "invalidLetter",
-        fn: (value) => {
-          return invalidCharacters(value);
-        },
+        fn: invalidCharacters,
       },
     ],
   },

--- a/src/lib/validator.js
+++ b/src/lib/validator.js
@@ -2,10 +2,16 @@ const isValidNino = (value) => {
   return value
     .replaceAll(" ", "")
     .toUpperCase()
+    .match(/^[A-Z]{2}[0-9]{6}[A-Z]{1}$/);
+};
+
+const invalidCharacters = (value) => {
+  return value
+    .replaceAll(" ", "")
+    .toUpperCase()
     .match(
-      "" ||
-        /^(?!BG|GB|KN|NK|NT|TN|ZZ)[ABCEGHJKLMNOPRSTWXYZ][ABCEGHJKLMNPRSTWXYZ][0-9]{6}[ABCD]$/i
+      /^(BG|GB|KN|NK|NT|TN|ZZ)|^[DFIQUV][A-Z]|^[A-Z][DFIQUV]|^[A-Z]O|^[0-9]{6}[^ABCD]$/
     );
 };
 
-module.exports = { isValidNino };
+module.exports = { isValidNino, invalidCharacters };

--- a/src/lib/validator.js
+++ b/src/lib/validator.js
@@ -3,7 +3,7 @@ const isValidNino = (value) => {
   if (formattedValue.length < 9 || formattedValue.length > 9) {
     return null;
   }
-  const formatRegex = /^[A-Z]{2}[0-9]{6}[A-Z]$/i;
+  const formatRegex = /^[A-Z]{2}\d{6}[A-Z]$/i;
   if (!formatRegex.test(formattedValue)) {
     return null;
   }
@@ -16,7 +16,7 @@ const invalidCharacters = (value) => {
     return formattedValue;
   }
   const invalidRegex =
-    /^(BG|GB|KN|NK|NT|TN|ZZ)|^[DFIQUV][A-Z]|^[A-Z][DFIQUV]|^[A-Z]O|[A-Z]{2}[0-9]{6}[^ABCD]$/;
+    /^(BG|GB|KN|NK|NT|TN|ZZ)|^[DFIQUV][A-Z]|^[A-Z][DFIQUV]|^[A-Z]O|[A-Z]{2}\d{6}[^ABCD]$/;
   if (invalidRegex.test(formattedValue)) {
     return null;
   }

--- a/src/lib/validator.js
+++ b/src/lib/validator.js
@@ -15,9 +15,17 @@ const invalidCharacters = (value) => {
   if (isValidNino(formattedValue) !== formattedValue) {
     return formattedValue;
   }
-  const invalidRegex =
-    /^(BG|GB|KN|NK|NT|TN|ZZ)|^[DFIQUV][A-Z]|^[A-Z][DFIQUV]|^[A-Z]O|[A-Z]{2}\d{6}[^ABCD]$/;
-  if (invalidRegex.test(formattedValue)) {
+  const prefixRegex = /^(?:BG|GB|KN|NK|NT|TN|ZZ)/;
+  const firstLetterRegex = /^[DFIQUV][A-Z]/;
+  const secondLetterRegex = /^[A-Z][DFIQUVO]/;
+  const lastLetterRegex = /[A-Z]{2}\d{6}[^ABCD]$/;
+
+  if (
+    prefixRegex.test(formattedValue) ||
+    firstLetterRegex.test(formattedValue) ||
+    secondLetterRegex.test(formattedValue) ||
+    lastLetterRegex.test(formattedValue)
+  ) {
     return null;
   }
   return formattedValue;

--- a/src/lib/validator.js
+++ b/src/lib/validator.js
@@ -1,34 +1,24 @@
 const isValidNino = (value) => {
   const formattedValue = value.replaceAll(" ", "").toUpperCase();
-  if (formattedValue.length < 9 || formattedValue.length > 9) {
-    return null;
-  }
+
   const formatRegex = /^[A-Z]{2}\d{6}[A-Z]$/i;
-  if (!formatRegex.test(formattedValue)) {
-    return null;
-  }
-  return formattedValue;
+  return formatRegex.test(formattedValue);
 };
 
 const invalidCharacters = (value) => {
   const formattedValue = value.replaceAll(" ", "").toUpperCase();
-  if (isValidNino(formattedValue) !== formattedValue) {
-    return formattedValue;
-  }
+
   const prefixRegex = /^(?:BG|GB|KN|NK|NT|TN|ZZ)/;
   const firstLetterRegex = /^[DFIQUV][A-Z]/;
   const secondLetterRegex = /^[A-Z][DFIQUVO]/;
   const lastLetterRegex = /[A-Z]{2}\d{6}[^ABCD]$/;
 
-  if (
+  return !(
     prefixRegex.test(formattedValue) ||
     firstLetterRegex.test(formattedValue) ||
     secondLetterRegex.test(formattedValue) ||
     lastLetterRegex.test(formattedValue)
-  ) {
-    return null;
-  }
-  return formattedValue;
+  );
 };
 
 module.exports = { isValidNino, invalidCharacters };

--- a/src/lib/validator.js
+++ b/src/lib/validator.js
@@ -1,17 +1,26 @@
 const isValidNino = (value) => {
-  return value
-    .replaceAll(" ", "")
-    .toUpperCase()
-    .match(/^[A-Z]{2}[0-9]{6}[A-Z]{1}$/);
+  const formattedValue = value.replaceAll(" ", "").toUpperCase();
+  if (formattedValue.length < 9 || formattedValue.length > 9) {
+    return null;
+  }
+  const formatRegex = /^[A-Z]{2}[0-9]{6}[A-Z]$/i;
+  if (!formatRegex.test(formattedValue)) {
+    return null;
+  }
+  return formattedValue;
 };
 
 const invalidCharacters = (value) => {
-  return value
-    .replaceAll(" ", "")
-    .toUpperCase()
-    .match(
-      /^(BG|GB|KN|NK|NT|TN|ZZ)|^[DFIQUV][A-Z]|^[A-Z][DFIQUV]|^[A-Z]O|^[0-9]{6}[^ABCD]$/
-    );
+  const formattedValue = value.replaceAll(" ", "").toUpperCase();
+  if (isValidNino(formattedValue) !== formattedValue) {
+    return formattedValue;
+  }
+  const invalidRegex =
+    /^(BG|GB|KN|NK|NT|TN|ZZ)|^[DFIQUV][A-Z]|^[A-Z][DFIQUV]|^[A-Z]O|[A-Z]{2}[0-9]{6}[^ABCD]$/;
+  if (invalidRegex.test(formattedValue)) {
+    return null;
+  }
+  return formattedValue;
 };
 
 module.exports = { isValidNino, invalidCharacters };

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -7,6 +7,7 @@ nationalInsuranceNumber:
   validation:
     required: Rhowch eich rhif Yswiriant Gwladol
     nino: Rhowch eich rhif Yswiriant Gwladol yn y ffurf cywir
+    invalidLetter: Nid yw'r rhif Yswiriant Gwladol a roddwyd gennych yn gywir, gwiriwch ef a rhowch gynnig arall
 
 retryNationalInsuranceRadio:
   label: Beth hoffech chi ei wneud?

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -7,6 +7,7 @@ nationalInsuranceNumber:
   validation:
     required: Enter your National Insurance number
     nino: Enter your National Insurance number in the correct format
+    invalidLetter: The National Insurance number you entered is not correct, check it and try again
 
 retryNationalInsuranceRadio:
   label: What would you like to do?

--- a/tests/browser/features/error-bad-nino.feature
+++ b/tests/browser/features/error-bad-nino.feature
@@ -2,10 +2,36 @@ Feature: Error handling
   Nino Errors in the middle of the journey
 
   @mock-api:success
-  Scenario: Error Bad Nino
+  Scenario Outline: Error Bad Nino for invalid nino regex
     Given that "Happy Harriet" user is going through the system
     And they have started the journey
     And they should see the national insurance number page
-    And they enter a bad national insurance number
+    And they enter a "<invalidNino>" national insurance number value
     When they continue from national insurance number
-    Then they should see the validation error page
+    Then they should see the "nino" validation error page
+
+    Examples:
+      | invalidNino          |
+      | A                    |
+      | ABCDEFGHIJ           |
+      | 123456789            |
+      | ABCD12345D           |
+      | 12345ABCDEFGHIJKLMNO |
+      | PE12JGB31DE          |
+
+  Scenario Outline: Error Bad Nino for invalid character regex
+    Given that "Happy Harriet" user is going through the system
+    And they have started the journey
+    And they should see the national insurance number page
+    And they enter a "<invalidCharacter>" national insurance number
+    When they continue from national insurance number
+    Then they should see the "invalidLetter" validation error page
+
+    Examples:
+      | invalidCharacter |
+      | TN123456V        |
+      | TN123456A        |
+      | AA123456X        |
+      | PO123456A        |
+      | GB123456C        |
+      | VA123456A        |

--- a/tests/browser/step_definitions/national-insurance-number.js
+++ b/tests/browser/step_definitions/national-insurance-number.js
@@ -13,12 +13,28 @@ Then("they continue from national insurance number", async function () {
   await ninoPage.continue();
 });
 
-Then(/^they should see the validation error page$/, async function () {
-  const ninoPage = new NinoPage(this.page);
-  expect(ninoPage.isCurrentPage()).to.be.true;
+Then(
+  "they should see the {string} validation error page",
+  async function (errorType) {
+    const ninoPage = new NinoPage(this.page);
+    expect(ninoPage.isCurrentPage()).to.be.true;
+    expect(ninoPage.hasErrorSummary).to.not.be.false;
 
-  expect(ninoPage.hasErrorSummary).to.not.be.false;
-});
+    const errorMessage = await ninoPage.hasErrorSummary().innerText();
+
+    if (errorType === "nino") {
+      expect(errorMessage).to.include(
+        "Enter your National Insurance number in the correct format"
+      );
+    } else if (errorType === "invalidLetter") {
+      expect(errorMessage).to.include(
+        "The National Insurance number you entered is not correct, check it and try again"
+      );
+    } else {
+      throw new Error(`Unexpected error type: ${errorType}`);
+    }
+  }
+);
 
 When(/^they enter their national insurance number$/, async function () {
   const ninoPage = new NinoPage(this.page);
@@ -26,11 +42,23 @@ When(/^they enter their national insurance number$/, async function () {
   await ninoPage.enterNINO("AA123455D");
 });
 
-When(/^they enter a bad national insurance number$/, async function () {
-  const ninoPage = new NinoPage(this.page);
+When(
+  "they enter a {string} national insurance number",
+  async function (invalidCharacter) {
+    const ninoPage = new NinoPage(this.page);
 
-  await ninoPage.enterNINO("QQ123456Q");
-});
+    await ninoPage.enterNINO(invalidCharacter);
+  }
+);
+
+When(
+  "they enter a {string} national insurance number value",
+  async function (invalidNino) {
+    const ninoPage = new NinoPage(this.page);
+
+    await ninoPage.enterNINO(invalidNino);
+  }
+);
 
 When(
   "they enter a national insurance number that requires a retry",

--- a/tests/unit/lib/helpers.js
+++ b/tests/unit/lib/helpers.js
@@ -61,12 +61,12 @@ global.beforeEach(() => {
 
 const testNinoValidation = (ninoArg) => {
   const isValidResult = isValidNino(ninoArg);
-  if (isValidResult === null) {
-    expect(isValidResult).to.be.null;
+  if (!isValidResult) {
+    expect(isValidResult).to.be.false;
   } else {
     const invalidCharResult = invalidCharacters(ninoArg);
-    expect(invalidCharResult).to.be.null;
-    if (invalidCharResult !== null) {
+    expect(invalidCharResult).to.be.false;
+    if (invalidCharResult) {
       expect(invalidCharResult).to.equal(
         ninoArg.replaceAll(" ", "").toUpperCase()
       );

--- a/tests/unit/lib/helpers.js
+++ b/tests/unit/lib/helpers.js
@@ -1,12 +1,7 @@
 const { mockRequest, mockResponse } = require("jest-mock-req-res");
-const { expect } = require("chai");
 
 const JourneyModel = require("hmpo-form-wizard/lib/journey-model");
 const WizardModel = require("hmpo-form-wizard/lib/wizard-model.js");
-const {
-  isValidNino,
-  invalidCharacters,
-} = require("../../../src/lib/validator");
 
 /* global createDefaultReqResNext */
 global.createDefaultReqResNext = () => {
@@ -58,19 +53,3 @@ global.beforeEach(() => {
   global.res = setup.res;
   global.next = setup.next;
 });
-
-const testNinoValidation = (ninoArg) => {
-  const isValidResult = isValidNino(ninoArg);
-  if (!isValidResult) {
-    expect(isValidResult).to.be.false;
-  } else {
-    const invalidCharResult = invalidCharacters(ninoArg);
-    expect(invalidCharResult).to.be.false;
-    if (invalidCharResult) {
-      expect(invalidCharResult).to.equal(
-        ninoArg.replaceAll(" ", "").toUpperCase()
-      );
-    }
-  }
-};
-module.exports = { testNinoValidation };

--- a/tests/unit/lib/helpers.js
+++ b/tests/unit/lib/helpers.js
@@ -1,7 +1,12 @@
 const { mockRequest, mockResponse } = require("jest-mock-req-res");
+const { expect } = require("chai");
 
 const JourneyModel = require("hmpo-form-wizard/lib/journey-model");
 const WizardModel = require("hmpo-form-wizard/lib/wizard-model.js");
+const {
+  isValidNino,
+  invalidCharacters,
+} = require("../../../src/lib/validator");
 
 /* global createDefaultReqResNext */
 global.createDefaultReqResNext = () => {
@@ -53,3 +58,19 @@ global.beforeEach(() => {
   global.res = setup.res;
   global.next = setup.next;
 });
+
+const testNinoValidation = (ninoArg) => {
+  const isValidResult = isValidNino(ninoArg);
+  if (isValidResult === null) {
+    expect(isValidResult).to.be.null;
+  } else {
+    const invalidCharResult = invalidCharacters(ninoArg);
+    expect(invalidCharResult).to.be.null;
+    if (invalidCharResult !== null) {
+      expect(invalidCharResult).to.equal(
+        ninoArg.replaceAll(" ", "").toUpperCase()
+      );
+    }
+  }
+};
+module.exports = { testNinoValidation };

--- a/tests/unit/src/lib/validator.test.js
+++ b/tests/unit/src/lib/validator.test.js
@@ -77,53 +77,51 @@ const bad_length_ninos = [
   "AA",
   "A",
   "",
+  "abc def",
+  "a b c d e f",
+  "ab1cd 2",
 ];
 
 describe("should fail all the bad ninos", () => {
   test.each(bad_prefixes_ninos)(
-    "given bad prefix nino of %p, returns null string",
+    "given bad prefix nino of %p, returns false",
     (ninoArg) => {
       testNinoValidation(ninoArg);
     }
   );
   test.each(bad_unused_prefixes_ninos)(
-    "given unused prefix nino of %p, returns null string",
+    "given unused prefix nino of %p, returns false",
     (ninoArg) => {
       testNinoValidation(ninoArg);
     }
   );
   test.each(bad_suffixes_ninos)(
-    "given bad suffix nino of %p, returns null string",
+    "given bad suffix nino of %p, returns false",
     (ninoArg) => {
       testNinoValidation(ninoArg);
     }
   );
   test.each(bad_length_ninos)(
-    "given bad length nino of %p, returns null string",
+    "given bad length nino of %p, returns false",
     (ninoArg) => {
       testNinoValidation(ninoArg);
     }
   );
 });
 
-describe("invoke the invalidCharacters function", () => {
-  it("should return formattedValue when isValidNino does not return the same value", () => {
-    const testValue = "123456";
-    const formattedValue = testValue.replaceAll(" ", "").toUpperCase();
-    const isValidNinoResult = isValidNino(formattedValue);
-    expect(isValidNinoResult).to.not.equal(formattedValue);
-    const result = invalidCharacters(formattedValue);
-    expect(result).to.equal(formattedValue);
-  });
-});
-
 describe("should return all the good ninos", () => {
-  test.each(good_edge_case_ninos)("returns the given nino of %p", (ninoArg) => {
-    const result = isValidNino(ninoArg);
-    expect(result).to.equal(ninoArg.replaceAll(" ", "").toUpperCase());
-  });
-  test.each(good_edge_case_ninos)("returns the given nino of %p", (ninoArg) => {
-    const result = invalidCharacters(ninoArg);
-    expect(result).to.equal(ninoArg.replaceAll(" ", "").toUpperCase());
-  });
+  test.each(good_edge_case_ninos)(
+    "isValidNino returns true for the given nino of %p",
+    (ninoArg) => {
+      const result = isValidNino(ninoArg);
+      expect(result).to.be.true;
+    }
+  );
+  test.each(good_edge_case_ninos)(
+    "invalidCharacters returns true for the given nino of %p",
+    (ninoArg) => {
+      const result = invalidCharacters(ninoArg);
+      expect(result).to.be.true;
+    }
+  );
 });

--- a/tests/unit/src/lib/validator.test.js
+++ b/tests/unit/src/lib/validator.test.js
@@ -1,4 +1,7 @@
-const { isValidNino } = require("../../../../src/lib/validator");
+const {
+  isValidNino,
+  invalidCharacters,
+} = require("../../../../src/lib/validator");
 const { expect } = require("chai");
 const { testNinoValidation } = require("../../lib/helpers");
 
@@ -30,6 +33,7 @@ const good_edge_case_ninos = [
   "aa 28 39 02 d",
   "aa283902d",
 ];
+
 const bad_prefixes_ninos = [
   "DA283902A",
   "FA283902A",
@@ -102,9 +106,24 @@ describe("should fail all the bad ninos", () => {
   );
 });
 
+describe("invoke the invalidCharacters function", () => {
+  it("should return formattedValue when isValidNino does not return the same value", () => {
+    const testValue = "123456";
+    const formattedValue = testValue.replaceAll(" ", "").toUpperCase();
+    const isValidNinoResult = isValidNino(formattedValue);
+    expect(isValidNinoResult).to.not.equal(formattedValue);
+    const result = invalidCharacters(formattedValue);
+    expect(result).to.equal(formattedValue);
+  });
+});
+
 describe("should return all the good ninos", () => {
   test.each(good_edge_case_ninos)("returns the given nino of %p", (ninoArg) => {
     const result = isValidNino(ninoArg);
+    expect(result).to.equal(ninoArg.replaceAll(" ", "").toUpperCase());
+  });
+  test.each(good_edge_case_ninos)("returns the given nino of %p", (ninoArg) => {
+    const result = invalidCharacters(ninoArg);
     expect(result).to.equal(ninoArg.replaceAll(" ", "").toUpperCase());
   });
 });

--- a/tests/unit/src/lib/validator.test.js
+++ b/tests/unit/src/lib/validator.test.js
@@ -1,4 +1,6 @@
 const { isValidNino } = require("../../../../src/lib/validator");
+const { expect } = require("chai");
+const { testNinoValidation } = require("../../lib/helpers");
 
 const good_edge_case_ninos = [
   "CA283902A",
@@ -77,36 +79,32 @@ describe("should fail all the bad ninos", () => {
   test.each(bad_prefixes_ninos)(
     "given bad prefix nino of %p, returns null string",
     (ninoArg) => {
-      const result = isValidNino(ninoArg);
-      expect(result).toBeNull();
+      testNinoValidation(ninoArg);
     }
   );
   test.each(bad_unused_prefixes_ninos)(
     "given unused prefix nino of %p, returns null string",
     (ninoArg) => {
-      const result = isValidNino(ninoArg);
-      expect(result).toBeNull();
+      testNinoValidation(ninoArg);
     }
   );
   test.each(bad_suffixes_ninos)(
     "given bad suffix nino of %p, returns null string",
     (ninoArg) => {
-      const result = isValidNino(ninoArg);
-      expect(result).toBeNull();
+      testNinoValidation(ninoArg);
     }
   );
   test.each(bad_length_ninos)(
     "given bad length nino of %p, returns null string",
     (ninoArg) => {
-      const result = isValidNino(ninoArg);
-      expect(result).toBeNull();
+      testNinoValidation(ninoArg);
     }
   );
 });
 
 describe("should return all the good ninos", () => {
   test.each(good_edge_case_ninos)("returns the given nino of %p", (ninoArg) => {
-    const result = isValidNino(ninoArg)[0];
-    expect(result).toEqual(ninoArg.replaceAll(" ", "").toUpperCase());
+    const result = isValidNino(ninoArg);
+    expect(result).to.equal(ninoArg.replaceAll(" ", "").toUpperCase());
   });
 });

--- a/tests/unit/src/lib/validator.test.js
+++ b/tests/unit/src/lib/validator.test.js
@@ -3,7 +3,6 @@ const {
   invalidCharacters,
 } = require("../../../../src/lib/validator");
 const { expect } = require("chai");
-const { testNinoValidation } = require("../../lib/helpers");
 
 const good_edge_case_ninos = [
   "CA283902A",
@@ -86,25 +85,33 @@ describe("should fail all the bad ninos", () => {
   test.each(bad_prefixes_ninos)(
     "given bad prefix nino of %p, returns false",
     (ninoArg) => {
-      testNinoValidation(ninoArg);
+      const invalidCharResult = invalidCharacters(ninoArg);
+
+      expect(invalidCharResult).to.be.false;
     }
   );
   test.each(bad_unused_prefixes_ninos)(
     "given unused prefix nino of %p, returns false",
     (ninoArg) => {
-      testNinoValidation(ninoArg);
+      const invalidCharResult = invalidCharacters(ninoArg);
+
+      expect(invalidCharResult).to.be.false;
     }
   );
   test.each(bad_suffixes_ninos)(
     "given bad suffix nino of %p, returns false",
     (ninoArg) => {
-      testNinoValidation(ninoArg);
+      const invalidCharResult = invalidCharacters(ninoArg);
+
+      expect(invalidCharResult).to.be.false;
     }
   );
   test.each(bad_length_ninos)(
     "given bad length nino of %p, returns false",
     (ninoArg) => {
-      testNinoValidation(ninoArg);
+      const result = isValidNino(ninoArg);
+
+      expect(result).to.be.false;
     }
   );
 });
@@ -114,6 +121,7 @@ describe("should return all the good ninos", () => {
     "isValidNino returns true for the given nino of %p",
     (ninoArg) => {
       const result = isValidNino(ninoArg);
+
       expect(result).to.be.true;
     }
   );
@@ -121,6 +129,7 @@ describe("should return all the good ninos", () => {
     "invalidCharacters returns true for the given nino of %p",
     (ninoArg) => {
       const result = invalidCharacters(ninoArg);
+
       expect(result).to.be.true;
     }
   );


### PR DESCRIPTION

## Proposed changes

### What changed

- Add new validation for the invalid prefix and suffix characters for nino
- Update existing validation so that the new validation is not overwritten
- Update unit and integration tests
- Updated the `validation.js` to check the following scenarios first to ensure its a valid NiNo before validating against the "invalidCharacter" regex: has too many characters, has too few characters, does not follow the 2 letters, 6 numbers, 1 letter format


https://github.com/user-attachments/assets/0e22a9b6-c59e-40aa-8b19-4ed9bac28821



- Added welsh translation
<img width="1089" alt="Screenshot 2025-02-14 at 17 03 07" src="https://github.com/user-attachments/assets/68071f11-1dc7-4a74-9ec5-d16d0b954534" />
<img width="1088" alt="Screenshot 2025-02-14 at 17 02 55" src="https://github.com/user-attachments/assets/a225e32b-33b1-4e16-a494-1e5388e07852" />


### Why did it change

So that users can be informed when entering National Insurance number containing invalid characters

### Issue tracking

- [OJ-3007](https://govukverify.atlassian.net/browse/OJ-3007)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3007]: https://govukverify.atlassian.net/browse/OJ-3007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ