### PR TITLE
OJ-2973: Remove check from url path

### DIFF
--- a/src/app/check/controllers/enter-national-insurance-number.js
+++ b/src/app/check/controllers/enter-national-insurance-number.js
@@ -14,7 +14,7 @@ const validateStatus = (status) => {
   return status >= 200 && status < 300;
 };
 
-class NationalInsuranceNumberController extends BaseController {
+class EnterNationalInsuranceNumberController extends BaseController {
   async saveValues(req, res, callback) {
     req.session.redirectToRetry = false;
     super.saveValues(req, res, async () => {
@@ -56,4 +56,4 @@ class NationalInsuranceNumberController extends BaseController {
   }
 }
 
-module.exports = NationalInsuranceNumberController;
+module.exports = EnterNationalInsuranceNumberController;

--- a/src/app/check/steps.js
+++ b/src/app/check/steps.js
@@ -1,4 +1,4 @@
-const ninoController = require("./controllers/national-insurance-number");
+const ninoController = require("./controllers/enter-national-insurance-number");
 const AbandonController = require("./controllers/abandon");
 
 module.exports = {
@@ -6,9 +6,9 @@ module.exports = {
     resetJourney: true,
     entryPoint: true,
     skip: true,
-    next: "national-insurance-number",
+    next: "enter-national-insurance-number",
   },
-  "/national-insurance-number": {
+  "/enter-national-insurance-number": {
     controller: ninoController,
     fields: ["nationalInsuranceNumber"],
     next: [
@@ -25,19 +25,19 @@ module.exports = {
       {
         field: "retryNationalInsuranceRadio",
         value: "retryNationalInsurance",
-        next: "national-insurance-number",
+        next: "enter-national-insurance-number",
       },
       "abandon",
     ],
   },
   "/how-continue-national-insurance": {
-    prereqs: ["/check"],
+    prereqs: ["/"],
     fields: ["abandonRadio"],
     next: [
       {
         field: "abandonRadio",
         value: "retryNationalInsurance",
-        next: "national-insurance-number",
+        next: "enter-national-insurance-number",
       },
       "abandon",
     ],

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -13,7 +13,7 @@ module.exports = {
   APP: {
     BASE_URL: process.env.EXTERNAL_WEBSITE_HOST || "http://localhost:5000",
     PATHS: {
-      CHECK: "/check",
+      CHECK: "/",
     },
     GTM: {
       ANALYTICS_COOKIE_DOMAIN:

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -70,4 +70,4 @@ error:
 abandonWarning:
   content: "Ni allwch ddychwelyd i'r sgrin hon os ydych yn chwilio am ffordd arall o brofi eich hunaniaeth."
 abandonLink:
-  content: "<a href='/check/how-continue-national-insurance' class='govuk-link' id='abandon-link' data-id='abandon'> Nid yw fy rhif Yswiriant Gwladol gennyf </a>"
+  content: "<a href='/how-continue-national-insurance' class='govuk-link' id='abandon-link' data-id='abandon'> Nid yw fy rhif Yswiriant Gwladol gennyf </a>"

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -1,4 +1,4 @@
-national-insurance-number:
+enter-national-insurance-number:
   title: "Rhowch eich Rhif Yswiriant Gwladol"
   h1: "Rhowch eich Rhif Yswiriant Gwladol"
   content:

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -70,4 +70,4 @@ error:
 abandonWarning:
   content: "You cannot return to this screen if you look for another way to prove your identity."
 abandonLink:
-  content: "<a href='/check/how-continue-national-insurance' class='govuk-link' id='abandon-link' data-id='abandon'> I do not have my National Insurance number </a>"
+  content: "<a href='/how-continue-national-insurance' class='govuk-link' id='abandon-link' data-id='abandon'> I do not have my National Insurance number </a>"

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -1,4 +1,4 @@
-national-insurance-number:
+enter-national-insurance-number:
   title: "Enter your National Insurance Number"
   h1: "Enter your National Insurance number"
   content:

--- a/src/views/check/enter-national-insurance-number.njk
+++ b/src/views/check/enter-national-insurance-number.njk
@@ -2,8 +2,8 @@
 {% from "hmpo-text/macro.njk" import hmpoText %}
 {% from "hmpo-form/macro.njk" import hmpoForm %}
 
-{% set hmpoPageKey = "national-insurance-number" %}
-{% set hmpoPageContent = "national-insurance-number" %}
+{% set hmpoPageKey = "enter-national-insurance-number" %}
+{% set hmpoPageContent = "enter-national-insurance-number" %}
 {% set gtmJourney = "check - middle" %}
 
 {% block mainContent %}
@@ -17,7 +17,7 @@
   {{ hmpoSubmit(ctx, {
     id: "continue",
     text: translate("buttons.checkAndContinue"),
-    attributes: {"data-nav": true,"data-link": "/national-insurance-number"}
+    attributes: {"data-nav": true,"data-link": "/enter-national-insurance-number"}
   }) }}
 
   <script nonce="{{ cspNonce }}">
@@ -56,7 +56,7 @@
         window.addEventListener('load', function () {
             window.DI.analyticsGa4.pageViewTracker.trackOnPageLoad({
                 statusCode: '200', // Access status code
-                englishPageTitle: '{{ translate("pages.national-insurance-number.title") }}',
+                englishPageTitle: '{{ translate("pages.enter-national-insurance-number.title") }}',
                 taxonomy_level1: 'web cri', // Access taxonomy level 1
                 taxonomy_level2: 'check hmrc', // Access taxonomy level 2
                 content_id: '093',

--- a/tests/browser/pages/abandon.js
+++ b/tests/browser/pages/abandon.js
@@ -4,7 +4,7 @@ module.exports = class PlaywrightDevPage {
    */
   constructor(page) {
     this.page = page;
-    this.path = "/check/how-continue-national-insurance";
+    this.path = "/how-continue-national-insurance";
   }
 
   async continue() {

--- a/tests/browser/pages/could-not-match-national-insurance.js
+++ b/tests/browser/pages/could-not-match-national-insurance.js
@@ -4,7 +4,7 @@ module.exports = class PlaywrightDevPage {
    */
   constructor(page) {
     this.page = page;
-    this.path = "/check/could-not-match-national-insurance";
+    this.path = "/could-not-match-national-insurance";
   }
 
   async continue() {

--- a/tests/browser/pages/nino.js
+++ b/tests/browser/pages/nino.js
@@ -4,7 +4,7 @@ module.exports = class PlaywrightDevPage {
    */
   constructor(page) {
     this.page = page;
-    this.path = "/check/national-insurance-number";
+    this.path = "/enter-national-insurance-number";
   }
 
   async continue() {

--- a/tests/unit/src/app/check/controllers/national-insurance-number.test.js
+++ b/tests/unit/src/app/check/controllers/national-insurance-number.test.js
@@ -1,5 +1,5 @@
 const BaseController = require("hmpo-form-wizard").Controller;
-const Controller = require("../../../../../../src/app/check/controllers/national-insurance-number");
+const Controller = require("../../../../../../src/app/check/controllers/enter-national-insurance-number");
 
 const {
   API: {


### PR DESCRIPTION
## Proposed changes

### What changed

Changes the base route `/check` -> `/`
Also changed `/national-insurance-number` -> `/enter-national-insurance-number`

URL paths changed;
`/check/national-insurance-number` → `/enter-national-insurance-number `
`/check/could-not-match-national-insurance` → `/could-not-match-national-insurance`
`/check/how-continue-national-insurance` → `/how-continue-national-insurance`

### Why did it change

UCD review - So that it aligns with the expected URL structure 

### Issue tracking

- [OJ-2973](https://govukverify.atlassian.net/browse/OJ-2973)

## Screenshot
![image](https://github.com/user-attachments/assets/d5237caf-c334-4ccd-b89a-5452a8d8a25a)


[OJ-2973]: https://govukverify.atlassian.net/browse/OJ-2973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ