### PR TITLE
Spike: Testing CRI entry session validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.668.0",
-        "@govuk-one-login/di-ipv-cri-common-express": "10.2.0",
+        "@govuk-one-login/di-ipv-cri-common-express": "10.4.0",
         "@govuk-one-login/frontend-analytics": "3.0.0",
         "@govuk-one-login/frontend-language-toggle": "1.1.0",
         "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
@@ -1518,9 +1518,9 @@
       }
     },
     "node_modules/@govuk-one-login/di-ipv-cri-common-express": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-10.2.0.tgz",
-      "integrity": "sha512-3/INFUB01V2Zhfx5L7cdJq8WXFwzZJaeLSJp7hb7OUsGGkusrJqx83ji3yAQgq4qngB7GZz1pAyAE5ep1hJaSw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-10.4.0.tgz",
+      "integrity": "sha512-Xa2v4+maq2l2yWEs2gaG1UOL3nlrT1VNg4+dTlGWaXNwdHZYGB/HAF8pbDKZg3S3lLRrMQP+RzSumYkGJmeNPA==",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.668.0",
-    "@govuk-one-login/di-ipv-cri-common-express": "10.2.0",
+    "@govuk-one-login/di-ipv-cri-common-express": "10.4.0",
     "@govuk-one-login/frontend-analytics": "3.0.0",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.0.0",

--- a/src/app/check/index.js
+++ b/src/app/check/index.js
@@ -4,6 +4,12 @@ const fields = require("./fields");
 
 const router = express.Router();
 
+const {
+  sessionCheckMiddleware,
+} = require("./middleware/session-check-middleware");
+
+router.use(sessionCheckMiddleware);
+
 router.use(
   require("hmpo-form-wizard")(steps, fields, {
     name: "check-hmrc",

--- a/src/app/check/middleware/session-check-middleware.js
+++ b/src/app/check/middleware/session-check-middleware.js
@@ -1,0 +1,18 @@
+const { PACKAGE_NAME } = require("../../../lib/config");
+const logger = require("hmpo-logger").get(PACKAGE_NAME);
+
+module.exports = {
+  sessionCheckMiddleware: async (req, res, next) => {
+    if (!req.session?.tokenId || !req.session?.authParams) {
+      logger.error(
+        "This request does not have the expected session data, unable to proceed."
+      );
+      const err = new Error("Request is missing session data");
+      err.status = 401;
+      err.code = "MISSING_SESSION_DATA";
+      next(err);
+    } else {
+      next();
+    }
+  },
+};

--- a/tests/browser/features/error-missing-session.feature
+++ b/tests/browser/features/error-missing-session.feature
@@ -1,0 +1,8 @@
+Feature: Error handling
+
+  API Errors at the start of the journey
+
+  Scenario: Session data missing from request error
+    Given that a user directly accesses the base url
+    When there is an immediate error
+    Then they should see the unrecoverable error page

--- a/tests/browser/pages/error.js
+++ b/tests/browser/pages/error.js
@@ -6,6 +6,10 @@ module.exports = class PlaywrightDevPage {
     this.page = page;
   }
 
+  async directlyAccessBaseUrl() {
+    await this.page.goto(process.env.WEBSITE_HOST || "http://localhost:5020");
+  }
+
   getErrorTitle() {
     return this.page.textContent('[data-id="error-title"]');
   }

--- a/tests/browser/step_definitions/errors.js
+++ b/tests/browser/step_definitions/errors.js
@@ -4,6 +4,11 @@ const { ErrorPage } = require("../pages");
 
 Given("they have started the journey", function () {});
 
+Given("that a user directly accesses the base url", async function () {
+  this.errorPage = new ErrorPage(this.page);
+  await this.errorPage.directlyAccessBaseUrl();
+});
+
 When("there is an immediate error", function () {});
 
 Then("they should see the unrecoverable error page", async function () {

--- a/tests/unit/src/app/check/middleware/session-check-middleware.test.js
+++ b/tests/unit/src/app/check/middleware/session-check-middleware.test.js
@@ -1,0 +1,69 @@
+const {
+  sessionCheckMiddleware,
+} = require("../../../../../../src/app/check/middleware/session-check-middleware");
+
+describe("Session Check Middleware", () => {
+  it("should call next with no error", async () => {
+    req.session.tokenId = "MockTokenID";
+    req.session.authParams = { mock: "mock" };
+
+    await sessionCheckMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("should call next with a error with the code MISSING_AUTHPARAMS", async () => {
+    await sessionCheckMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(
+      new Error("Request is missing session data")
+    );
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "MISSING_SESSION_DATA", status: 401 })
+    );
+  });
+
+  it("should call next with an error when no req.session.authParams.state value present", async () => {
+    req.session.tokenId = "MockTokenID";
+
+    await sessionCheckMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(
+      new Error("Request is missing session data")
+    );
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "MISSING_SESSION_DATA", status: 401 })
+    );
+  });
+
+  it("should call next with an error when no req.session.tokenId value present", async () => {
+    req.session.authParams = { mock: "mock" };
+
+    await sessionCheckMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(
+      new Error("Request is missing session data")
+    );
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "MISSING_SESSION_DATA" })
+    );
+  });
+
+  it("should call next with an error if req.session is undefined", async () => {
+    req = {};
+
+    await sessionCheckMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(
+      new Error("Request is missing session data")
+    );
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "MISSING_SESSION_DATA", status: 401 })
+    );
+  });
+});


### PR DESCRIPTION
## Proposed changes

### Background information

Since https://github.com/govuk-one-login/ipv-cri-check-hmrc-front/pull/354 - Removing `/check` from the base url we have since an increase in 5XX errors. This is due to users now accessing `/` redirect to the `/enter-national-insurance-page` and can enter a nino resulting in a 5XX error as no session exists. This is the same issue across CRI's e.g. address-cri, it's more frequent in apps without a base route. 

Highlighted line is where the PR was merged.
![image](https://github.com/user-attachments/assets/dd5bc25a-9b39-45ea-b46b-58d968900414)

### What changed

- Adds `sessionCheckMiddleware` that does a basic check on the request to see if it has been through OAuth prior to this. If it has not, an error is thrown that will result in a`401` and an error page. 
- Bumped common-express to include missing auth params error handling.

### Why did it change

Current behaviour;

1. User directly accesses our apps entry point (now `/` previously `/check`)
2. User is redirected to the `/enter-national-insurance-number` page.
3. User enters a nino.
4. The BE returns there is no session.
5. Our app throws up an error to common-express error handling.
6. A 500 is returned as there is no redirect uri as the user did not enter via the OAuth url.
7. User sees error page. 

With updating to common-express 10.3.0, step 6. will now return a 403 and render the error page. But it would be preferred then when a user that has obviously not accessed the app not via the OAuth endpoint they should immediately see the error page.

Desired behaviour;

1. User directly accesses our apps entry point (now `/` previously `/check`).
2. Throw up `MISSING_SESSION_DATA` - `401` error for common-express to handle.
3. A `401` is returned and the user sees error page. 

### Notes

This will likely increase the amount for 401 errors we see, as any requests to the app without session data will immediately return a 401 instead of requiring a user triggered BE request to cause an error. 

This is not a full proof method to stop users accessing our app without OAuth, it's purpose is;
- To return 401s and Error Pages for _the majority_ users/requests instead of redirecting them to the `/enter-national-insurance-page` that will fail no matter what they enter. 
- Reduce the amount of BE requests that return 4XX errors due to no session data.

After testing, we could move the middleware logic into common-express for all CRI's to use. 

## Screenshot
![image](https://github.com/user-attachments/assets/01be0763-1ef4-4caf-9dd3-df9bd432bc2a)