### PR TITLE
OJ-3109: Set NODE_ENV to production

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -429,6 +429,8 @@ Resources:
               Value: !Sub
                 - "${AWS::StackName}-sessions-${Environment}"
                 - Environment: !Ref Environment
+            - Name: NODE_ENV
+              Value: "production"
             - Name: UA_CONTAINER_ID
               Value: !If [IsProduction, "GTM-TT5HDKV", "GTM-TK92W68"]
             - Name: GA4_CONTAINER_ID


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Set NODE_ENV env var to production for deployed environments

### Why did it change

By not explicitly setting there is a possibility that some of our dependencies are operating in development mode which might be impacting our performance

I have regression tested with this change and seen no errors in logs or impact to the user journey.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3109](https://govukverify.atlassian.net/browse/OJ-3109)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [x] Documented in the [README](./blob/main/README.md)
- [x] Added to deployment repository
- [x] Added to local startup repository


[OJ-3109]: https://govukverify.atlassian.net/browse/OJ-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ