### PR TITLE
OJ-3187: Use TEST_ENVIRONMENT instead of stack outputs

### DIFF
--- a/tests/browser/run-tests-post-merge.sh
+++ b/tests/browser/run-tests-post-merge.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ENVIRONMENT=$(aws cloudformation describe-stacks --stack-name check-hmrc-cri-front --query "Stacks[0].Parameters[?ParameterKey=='Environment'].ParameterValue" --output text)
+ENVIRONMENT=$TEST_ENVIRONMENT
 RELYING_PARTY_URL=$(aws cloudformation describe-stacks --stack-name test-resources --query "Stacks[0].Outputs[?OutputKey=='TestHarnessExecuteUrl'].OutputValue" --output text)
 WEBSITE_HOST="https://review-hc.${ENVIRONMENT}.account.gov.uk"
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use `TEST_ENVIRONMENT` instead of stack outputs

### Why did it change

Because the common pipeline role doesn't have access to describe the front stack
![image](https://github.com/user-attachments/assets/999064db-4cee-4ce3-b659-880ab9e72330)

`TEST_ENVIRONMENT` is exported by the [deploy pipeline](https://github.com/govuk-one-login/devplatform-utils/blob/5cdb0d36d0e2ee540afad252ed7a204cd223c633/sam-deploy-pipeline/template.yaml#L3177)

Front pipeline step still passes when using new test image

![image](https://github.com/user-attachments/assets/239fde5c-1ceb-4f5a-b598-e2e3379eeccb)


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3187](https://govukverify.atlassian.net/browse/OJ-3187)




[OJ-3187]: https://govukverify.atlassian.net/browse/OJ-3187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ