### PR TITLE
OJ-3239: Enable branding in int

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -92,7 +92,7 @@ Mappings:
       minECSCount: 2
       maxECSCount: 4
       deviceIntelligenceEnabled: true
-      may2025RebrandEnabled: false
+      may2025RebrandEnabled: true
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       minECSCount: 6


### PR DESCRIPTION
## Proposed changes

### What changed

Enable `may2025RebrandEnabled` in integration

### Why did it change

To align with the overall implementation plan and as confirmed that integration enablement supports E2E testing beginning W/C 14th July.

### Issue tracking

- [OJ-3239](https://govukverify.atlassian.net/browse/OJ-3239)


[OJ-3239]: https://govukverify.atlassian.net/browse/OJ-3239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ