### PR TITLE
OJ-3322: chore - update frontend-ui package with the latest FEC changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@govuk-one-login/frontend-device-intelligence": "1.1.0",
         "@govuk-one-login/frontend-language-toggle": "1.1.0",
         "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
-        "@govuk-one-login/frontend-ui": "1.3.9",
+        "@govuk-one-login/frontend-ui": "1.3.12",
         "@govuk-one-login/frontend-vital-signs": "0.1.3",
         "axios": "1.11.0",
         "cfenv": "1.2.4",
@@ -1466,9 +1466,10 @@
       }
     },
     "node_modules/@govuk-one-login/frontend-ui": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-ui/-/frontend-ui-1.3.9.tgz",
-      "integrity": "sha512-PYrSRlqCauBAaObzeWchGT90B61pzt9Abjkx2tvdxZqzDBIfV1OPzHYS4Scd45ilVkY4O4CafRVqEPTJl0XCtw==",
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-ui/-/frontend-ui-1.3.12.tgz",
+      "integrity": "sha512-EKf43hi61A5IhIlaFRO2gPlOTPkHvRDBLCiBGyWwppibDUvN+tYdvlhtn1UDsYZaHRXSl6cow/1ILE/DOwH3Vg==",
+      "license": "ISC",
       "dependencies": {
         "js-yaml": "^4.1.0",
         "pino": "8.20.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@govuk-one-login/frontend-device-intelligence": "1.1.0",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
-    "@govuk-one-login/frontend-ui": "1.3.9",
+    "@govuk-one-login/frontend-ui": "1.3.12",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",
     "axios": "1.11.0",
     "cfenv": "1.2.4",


### PR DESCRIPTION


## Proposed changes

### What changed

- Bumped `frontend-ui` package to include the FEC fix

Before - currently on stubs:


https://github.com/user-attachments/assets/11f66925-5042-40c4-9542-d91340204f6b



Now - FEC fix:

https://github.com/user-attachments/assets/e58bcb2d-0166-46dd-92c2-07618d3901fc



### Why did it change

To enable branding changes.

### Issue tracking
- [OJ-3322](https://govukverify.atlassian.net/browse/OJ-3322)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3322]: https://govukverify.atlassian.net/browse/OJ-3322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ