### PR TITLE
OJ-3346: Axios is vulnerable to DoS attack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
         "@govuk-one-login/frontend-ui": "1.3.12",
         "@govuk-one-login/frontend-vital-signs": "0.1.3",
-        "axios": "1.11.0",
+        "axios": "1.12.0",
         "cfenv": "1.2.4",
         "connect-dynamodb": "3.0.3",
         "dotenv": "16.4.5",
@@ -3414,9 +3414,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
     "@govuk-one-login/frontend-ui": "1.3.12",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",
-    "axios": "1.11.0",
+    "axios": "1.12.0",
     "cfenv": "1.2.4",
     "connect-dynamodb": "3.0.3",
     "dotenv": "16.4.5",


### PR DESCRIPTION
## Proposed changes

Addresses the above vulnerability by updating axios to version 1.12.0

### What changed

see: https://github.com/govuk-one-login/ipv-cri-check-hmrc-front/security/dependabot/42

- [OJ-3346](https://govukverify.atlassian.net/browse/OJ-3346)




