### PR TITLE
OJ-3436: fix - add a small loop to find device intelligence cookie

### DIFF
--- a/tests/browser/step_definitions/cookies.js
+++ b/tests/browser/step_definitions/cookies.js
@@ -2,7 +2,17 @@ const { Then } = require("@cucumber/cucumber");
 const { expect } = require("chai");
 
 Then("the {word} cookie has been set", async function (cookieName) {
-  const cookies = await this.page.context().cookies();
-  const expectedCookie = cookies.find((cookie) => cookie.name === cookieName);
-  expect(expectedCookie).to.exist;
+  const deadline = Date.now() + 5000;
+  let cookie;
+
+  while (Date.now() < deadline) {
+    const cookies = await this.page.context().cookies([this.page.url()]);
+    cookie = cookies.find(
+      (expectedCookie) => expectedCookie.name === cookieName
+    );
+    if (cookie) break;
+    await this.page.waitForTimeout(150);
+  }
+
+  expect(cookie, `Cookie ${cookieName} not found within 5s`).to.exist;
 });


### PR DESCRIPTION

## Proposed changes

### What changed

- Added a 5 second loop to pull the `di-device-intelligence` cookie from the current page to prevent undefined from being shown.

### Why did it change

Intermittent failures within the check-hmrc pipelines, showing `undefined` rather than the cookie being set

### Issue tracking

- [OJ-3436](https://govukverify.atlassian.net/browse/OJ-3436)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3436]: https://govukverify.atlassian.net/browse/OJ-3436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ