### PR TITLE
OJ-3355: Update AccessLogsBucketPolicy to Deny non https request

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -208,6 +208,18 @@ Resources:
               - s3:PutObject
             Resource:
               - !Sub arn:aws:s3:::${AccessLogsBucket}/${AWS::StackName}-${Environment}/AWSLogs/${AWS::AccountId}/*
+          - Effect: Deny
+            Resource:
+              - !GetAtt AccessLogsBucket.Arn
+              - !Sub "${AccessLogsBucket.Arn}/*"
+            Principal: "*"
+            Action:
+              - "s3:*"
+            Condition:
+              Bool:
+                "aws:SecureTransport": false
+              NumericLessThan:
+                "s3:TlsVersion": "1.2"
 
   # Private Application Load Balancer
   LoadBalancer:


### PR DESCRIPTION
## Proposed changes

S3 buckets should have policies that require requests to use SSL/TLS, by having a policy that denies HTTP requests. 

### Why did it change

This means that data in transit is encrypted which is a security best practise https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html#transit 

