### PR TITLE
OJ-3446: Apply FMS tags to APIGW + ELB outside int/prod

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -64,6 +64,12 @@ Conditions:
 
   EnableSpotArmInstance: !Equals [!Ref Environment, dev]
 
+  IsProductionOrIntegrationEnvironment: !Or
+    - !Equals [!Ref Environment, production]
+    - !Equals [!Ref Environment, integration]
+  IsNotProductionOrIntegrationEnvironment:
+    !Not [!Condition IsProductionOrIntegrationEnvironment]
+
 Mappings:
   StaticVariables:
     Urls:
@@ -253,6 +259,11 @@ Resources:
       Tags:
         - Key: FMSRegionalPolicy
           Value: false
+        - !If
+          - IsNotProductionOrIntegrationEnvironment
+          - Key: CustomPolicy
+            Value: "true"
+          - !Ref AWS::NoValue
 
   LoadBalancerListenerTargetGroupECS:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
@@ -678,11 +689,18 @@ Resources:
         - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
         - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
       SecurityGroupIds: []
+
   ApiGwHttpEndpoint:
     Type: "AWS::ApiGatewayV2::Api"
     Properties:
       Name: !Sub ${AWS::StackName}-${Environment}
       ProtocolType: HTTP
+      Tags:
+        FMSRegionalPolicy: false
+        CustomPolicy: !If
+          - IsNotProductionOrIntegrationEnvironment
+          - "true"
+          - !Ref AWS::NoValue
 
   ApiGwHttpEndpointIntegration:
     Type: "AWS::ApiGatewayV2::Integration"
@@ -727,6 +745,12 @@ Resources:
           "responseLength":"$context.responseLength",
           "responseLatency":"$context.responseLatency"
           }
+      Tags:
+        FMSRegionalPolicy: false
+        CustomPolicy: !If
+          - IsNotProductionOrIntegrationEnvironment
+          - "true"
+          - !Ref AWS::NoValue
 
   APIGWAccessLogsGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Proposed changes

### What changed

- Applied FMS regional policy tags to API Gateway & load balancer in dev+build+staging

### Why did it change

- The new FMS policy improves the security stance of the CRI

### Issue tracking

- OJ-3446

## Evidence

<img width="3186" height="1208" alt="image" src="https://github.com/user-attachments/assets/09fcd31c-9964-429e-89b2-69c898b87868" />

<img width="3212" height="1500" alt="image" src="https://github.com/user-attachments/assets/f380d3f5-079e-4a9f-b9f2-9b3b06d93659" />

<img width="3144" height="1504" alt="image" src="https://github.com/user-attachments/assets/e4f96c9c-93b9-40f8-b1e0-ebdbd10af9b9" />

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
