### PR TITLE
OJ-3642: Enable pino; use info/info/warn/warn/warn log levels

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -86,30 +86,35 @@ Mappings:
       maxECSCount: 4
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
+      logLevel: "info"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       minECSCount: 6
       maxECSCount: 60
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
+      logLevel: "info"
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       minECSCount: 2
       maxECSCount: 4
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
+      logLevel: "warn"
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       minECSCount: 2
       maxECSCount: 4
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
+      logLevel: "warn"
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       minECSCount: 6
       maxECSCount: 60
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
+      logLevel: "warn"
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
     eu-west-2:
@@ -519,6 +524,13 @@ Resources:
                   EnvironmentConfiguration,
                   !Ref Environment,
                   may2025RebrandEnabled,
+                ]
+            - Name: LOG_LEVEL
+              Value:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  logLevel,
                 ]
           Secrets:
             - Name: DT_TENANT

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -86,6 +86,7 @@ Mappings:
       maxECSCount: 4
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
+      pinoLoggerEnabled: "true"
       logLevel: "info"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -93,6 +94,7 @@ Mappings:
       maxECSCount: 60
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
+      pinoLoggerEnabled: "true"
       logLevel: "info"
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -100,6 +102,7 @@ Mappings:
       maxECSCount: 4
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
+      pinoLoggerEnabled: "false"
       logLevel: "warn"
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -107,6 +110,7 @@ Mappings:
       maxECSCount: 4
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
+      pinoLoggerEnabled: "false"
       logLevel: "warn"
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
@@ -114,6 +118,7 @@ Mappings:
       maxECSCount: 60
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
+      pinoLoggerEnabled: "false"
       logLevel: "warn"
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
@@ -531,6 +536,13 @@ Resources:
                   EnvironmentConfiguration,
                   !Ref Environment,
                   logLevel,
+                ]
+            - Name: USE_PINO_LOGGER
+              Value:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  pinoLoggerEnabled,
                 ]
           Secrets:
             - Name: DT_TENANT

--- a/package-lock.json
+++ b/package-lock.json
@@ -5988,9 +5988,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.1005.0",
-        "@govuk-one-login/di-ipv-cri-common-express": "13.1.0",
+        "@govuk-one-login/di-ipv-cri-common-express": "13.2.0",
         "@govuk-one-login/frontend-analytics": "4.0.5",
         "@govuk-one-login/frontend-device-intelligence": "1.1.0",
         "@govuk-one-login/frontend-language-toggle": "1.1.0",
@@ -1399,9 +1399,9 @@
       }
     },
     "node_modules/@govuk-one-login/di-ipv-cri-common-express": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-13.1.0.tgz",
-      "integrity": "sha512-T0HN6Us0PLpSts6ENY6pun4w0jxYqed9jw3pcWrgvRRYappMETPHOTpbPl9in87yZTYqXipaM3AR/UTuFlkkiA==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-13.2.0.tgz",
+      "integrity": "sha512-7TAUrP6FeQYi1xxuIhQJrSlfbN7dr1XOjESMp8CPyde+ftaY3PaRMCe+qDUx7P4+YrX3+YHUeEo75/AV3HDZ5g==",
       "license": "MIT",
       "dependencies": {
         "@govuk-one-login/frontend-ui": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.1005.0",
-    "@govuk-one-login/di-ipv-cri-common-express": "13.1.0",
+    "@govuk-one-login/di-ipv-cri-common-express": "13.2.0",
     "@govuk-one-login/frontend-analytics": "4.0.5",
     "@govuk-one-login/frontend-device-intelligence": "1.1.0",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -29,7 +29,7 @@ module.exports = {
     DEVICE_INTELLIGENCE_DOMAIN:
       process.env.DEVICE_INTELLIGENCE_DOMAIN || "account.gov.uk",
   },
-  LOG_LEVEL: process.env.LOG_LEVEL || "request",
+  LOG_LEVEL: process.env.LOG_LEVEL || "info",
   AWS_REGION: process.env.AWS_REGION || "eu-west-2",
   PORT: process.env.PORT || 5000,
   SESSION_SECRET: process.env.SESSION_SECRET,


### PR DESCRIPTION
## Proposed changes

### What changed

- Enable pino logger in dev/build
- Configure log level in line with other CRIs:
  - dev: info
  - build: info
  - staging: warn
  - integration: warn
  - production: warn
- npm audit fix

### Why did it change

- We are moving away from hmpo-logger in the frontends
- Check HMRC log level config was inconsistent with other CRIs

### Issue tracking

- OJ-3642

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
