### PR TITLE
OJ-3654: Fix test docker image build

### DIFF
--- a/.github/workflows/push-test-docker-image.yml
+++ b/.github/workflows/push-test-docker-image.yml
@@ -32,7 +32,6 @@ jobs:
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
           repository: ${{ vars.IMAGE_REPOSITORY }}
           dockerfile: tests/browser/post-merge.Dockerfile
-          build-path: tests/browser
           image-tags: |
             ${{ github.head_ref || github.ref_name }}-${{ github.sha }}
             ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Proposed changes

### What changed

- Changed test image build workflow definition to build the image in the root of the repo

### Why did it change

The [test image build workflow is failing](https://github.com/govuk-one-login/ipv-cri-check-hmrc-front/actions/runs/24562296903) as the test image dockerfile now expects to be built in the root of the repo as we now need to include files in the root.

Files in the root need to be included as we have now merged the browser test dependencies into the root package-lock.json to create a single npm dependency tree for the whole repository.

### Issue tracking

- OJ-3654

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
