### PR TITLE
OJ-3654: Fix test image for sam-deploy-pipeline

### DIFF
--- a/tests/browser/post-merge.Dockerfile
+++ b/tests/browser/post-merge.Dockerfile
@@ -17,4 +17,8 @@ WORKDIR /app/tests/browser
 
 COPY tests/browser ./
 
-CMD [ "./run-tests-post-merge.sh" ]
+# sam-deploy-pipeline expects to be able to execute a file called run-tests.sh at the root of the filesystem
+# https://github.com/govuk-one-login/devplatform-deploy/blob/main/sam-deploy-pipeline/template.yaml
+RUN cp run-tests-post-merge.sh /run-tests.sh
+
+CMD [ "/run-tests.sh" ]

--- a/tests/browser/run-tests-post-merge.sh
+++ b/tests/browser/run-tests-post-merge.sh
@@ -10,4 +10,8 @@ export ENVIRONMENT
 export GITHUB_ACTIONS=true
 export USE_LOCAL_API=false
 
+# This script must be copied to the root of the image filesystem in the post-merge dockerfile.
+# Therefore, ensure that we cd to the browser tests directory before attempting to run them.
+cd /app/tests/browser || exit 1
+
 npm run test:browser -- --tags @post-merge


### PR DESCRIPTION
## Proposed changes

### What changed

- Updated post-merge dockerfile to create a run-tests.sh file at the root of the image filesystem
- Updated the relevant script to cd to the correct location (as it was before #505)

### Why did it change

- The sam-deploy-pipeline canary implementation expects to be able to find `run-tests.sh` at the root of the filesystem

### Issue tracking

- OJ-3654

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks