### PR TITLE
Revert "OJ-3643: Set USE_PINO_LOGGER to true in all envs"

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -86,6 +86,7 @@ Mappings:
       maxECSCount: 4
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
+      pinoLoggerEnabled: "true"
       logLevel: "info"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -93,6 +94,7 @@ Mappings:
       maxECSCount: 60
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
+      pinoLoggerEnabled: "true"
       logLevel: "info"
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -100,6 +102,7 @@ Mappings:
       maxECSCount: 4
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
+      pinoLoggerEnabled: "false"
       logLevel: "warn"
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -107,6 +110,7 @@ Mappings:
       maxECSCount: 4
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
+      pinoLoggerEnabled: "false"
       logLevel: "warn"
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
@@ -114,6 +118,7 @@ Mappings:
       maxECSCount: 60
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
+      pinoLoggerEnabled: "false"
       logLevel: "warn"
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
@@ -533,7 +538,12 @@ Resources:
                   logLevel,
                 ]
             - Name: USE_PINO_LOGGER
-              Value: true
+              Value:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  pinoLoggerEnabled,
+                ]
           Secrets:
             - Name: DT_TENANT
               ValueFrom: !Join


### PR DESCRIPTION
Noticed the logs have gone from this;
<img width="1610" height="781" alt="image" src="https://github.com/user-attachments/assets/cefbd42b-b986-4aee-ab12-36f1039411f9" />

to this;
<img width="1627" height="448" alt="image" src="https://github.com/user-attachments/assets/2c379469-a72b-4367-960a-c8769494d81d" />

A fix is needed in common-express, reverting until resolved.

Reverts govuk-one-login/ipv-cri-check-hmrc-front#509