### PR TITLE
OJ-3643: Bump common-express and use pino in staging

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -102,7 +102,7 @@ Mappings:
       maxECSCount: 4
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
-      pinoLoggerEnabled: "false"
+      pinoLoggerEnabled: "true"
       logLevel: "warn"
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       ],
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.1005.0",
-        "@govuk-one-login/di-ipv-cri-common-express": "13.2.0",
+        "@govuk-one-login/di-ipv-cri-common-express": "13.2.1",
         "@govuk-one-login/frontend-analytics": "4.0.5",
         "@govuk-one-login/frontend-device-intelligence": "1.1.0",
         "@govuk-one-login/frontend-language-toggle": "1.1.0",
@@ -2069,9 +2069,9 @@
       }
     },
     "node_modules/@govuk-one-login/di-ipv-cri-common-express": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-13.2.0.tgz",
-      "integrity": "sha512-7TAUrP6FeQYi1xxuIhQJrSlfbN7dr1XOjESMp8CPyde+ftaY3PaRMCe+qDUx7P4+YrX3+YHUeEo75/AV3HDZ5g==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-13.2.1.tgz",
+      "integrity": "sha512-rcQRjaC4H3WlAIK1p+sPLOMbaXhHAqoLIMlX6ZWfHzuI0tm1pTpkIwo+r8tkGTBrmR7z/QvBn+RqZdYqV4UxDA==",
       "license": "MIT",
       "dependencies": {
         "@govuk-one-login/frontend-ui": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.1005.0",
-    "@govuk-one-login/di-ipv-cri-common-express": "13.2.0",
+    "@govuk-one-login/di-ipv-cri-common-express": "13.2.1",
     "@govuk-one-login/frontend-analytics": "4.0.5",
     "@govuk-one-login/frontend-device-intelligence": "1.1.0",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",


### PR DESCRIPTION
## Proposed changes

### What changed

- Bump common-express to include the pino logging patches: https://github.com/govuk-one-login/ipv-cri-common-express/releases/tag/v13.2.1
- Use the `pino` logger in staging so I can see the logs in Splunk.

Note: Int & prod to follow. Want to check the logs in staging first.

### Issue tracking

- [OJ-3643](https://govukverify.atlassian.net/browse/OJ-3643)

[OJ-3643]: https://govukverify.atlassian.net/browse/OJ-3643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ