### PR TITLE
fix: IPS-2290 tune ECS auto-scaling policies for dual-CPU Fargate inst

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -89,7 +89,7 @@ Mappings:
       logLevel: "info"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      minECSCount: 6
+      minECSCount: 3
       maxECSCount: 60
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
@@ -875,7 +875,7 @@ Resources:
         MetricSpecifications:
           - PredefinedMetricPairSpecification:
               PredefinedMetricType: ECSServiceCPUUtilization
-            TargetValue: 60
+            TargetValue: 30
         Mode: ForecastOnly
         SchedulingBufferTime: 600
 
@@ -892,10 +892,10 @@ Resources:
         AdjustmentType: PercentChangeInCapacity
         Cooldown: 300
         StepAdjustments:
-          - MetricIntervalUpperBound: -20
-            MetricIntervalLowerBound: -40
+          - MetricIntervalUpperBound: -10
+            MetricIntervalLowerBound: -20
             ScalingAdjustment: -10
-          - MetricIntervalUpperBound: -40
+          - MetricIntervalUpperBound: -20
             ScalingAdjustment: -50
 
   StepScaleOutPolicy:
@@ -910,17 +910,14 @@ Resources:
       StepScalingPolicyConfiguration:
         AdjustmentType: PercentChangeInCapacity
         Cooldown: 60
-        MinAdjustmentMagnitude: 5
-        StepAdjustments:
-          - MetricIntervalUpperBound: 20
+        MinAdjustmentMagnitude: 3
+        StepAdjustments: #these bounds are tuned to 2 CPU instances because node will max one CPU
+          - MetricIntervalUpperBound: 10
             ScalingAdjustment: 100
-          - MetricIntervalLowerBound: 20
-            MetricIntervalUpperBound: 30
+          - MetricIntervalLowerBound: 10
+            MetricIntervalUpperBound: 15
             ScalingAdjustment: 200
-          - MetricIntervalLowerBound: 30
-            MetricIntervalUpperBound: 35
-            ScalingAdjustment: 300
-          - MetricIntervalLowerBound: 35
+          - MetricIntervalLowerBound: 15
             ScalingAdjustment: 500
 
   StepScaleOutAlarm:
@@ -930,7 +927,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref StepScaleOutPolicy
-      AlarmDescription: !Sub "FrontClusterOver60PercentCPU"
+      AlarmDescription: "FrontClusterOver30PercentCPU"
       ComparisonOperator: "GreaterThanThreshold"
       DatapointsToAlarm: "2"
       Dimensions:
@@ -944,7 +941,7 @@ Resources:
       Namespace: "AWS/ECS"
       Statistic: "Average"
       Period: "60"
-      Threshold: "60"
+      Threshold: "30"
 
   StepScaleInAlarm:
     DependsOn: ECSAutoScalingTarget
@@ -953,7 +950,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref StepScaleInPolicy
-      AlarmDescription: !Sub "FrontClusterUnder60PercentCPU"
+      AlarmDescription: "FrontClusterUnder30PercentCPU"
       ComparisonOperator: "LessThanThreshold"
       DatapointsToAlarm: "5"
       Dimensions:
@@ -967,7 +964,7 @@ Resources:
       Namespace: "AWS/ECS"
       Statistic: "Average"
       Period: "60"
-      Threshold: "60"
+      Threshold: "30"
 
   SessionsTable:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
Node.js is single-threaded so max CPU utilisation on a 2-vCPU task reports ~50%. Previous thresholds (60%) were unreachable, effectively disabling scaling.

## Proposed changes

### What changed

Changes:
- Reduce scale-out alarm threshold from 60% to 30%
- Reduce predictive scaling target from 60% to 30%
- Lower min instance count from 6 to 3 in build (3 AZs)
- Set MinAdjustmentMagnitude to 3
- Re-tune step adjustments to align with achievable CPU metrics
- Add scale-in steps to return to baseline after traffic subsides

Now the scaling alarms are triggered at 30% CPU utilisation. 

StepAdjustments are also adjusted for when to scale:

- **3** extra instances when CPU is utilised at **30%** (30 + 0) instead of 80% (60+20)
- **6** extra instances when CPU is utilised at **40%** (30 + 10) and 
- **15** extra instances when CPU is utilised at **45%** (30 +15)

and for scale in policies:

- Remove **10%** of instances when CPU drops below **20%** (30 - 10)
- Remove **50%** of instances when CPU drops below **10%** (30 - 20)

MinAdjustmentMagnitude of 3 which is the proposed minimum number of ECS instances will mean during a scaling event at least 3 new instances get created. 

### Why did it change

Currently the scaling policies are **ineffective**. They never work and that's because we have a dual CPU fargate instance running node application which is single thread. This means when the application reaches its full capacity we are only at 50% CPU capacity. Current scaling policies scale at 60% therefore we need to bring those values to under 50%.

**Financial benefits:**
Build and prod are set to 6 containers as the min ECS count. 6 containers cost around £500/ month. Reducing this to 3 containers can save up to £250 per month per account.
This means savings of £6k per year or £72k per year across all the CRIs.

We have only reduced the min count to 3 in build to run performance tests and ensure we can meet NFRs before making the same update in prod. 

### Issue tracking

- [IPS-2290](https://govukverify.atlassian.net/browse/IPS-2290)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-2290]: https://govukverify.atlassian.net/browse/IPS-2290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ