### PR TITLE
chore: bump axios to 1.16.0 and fast-xml-builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
         "@govuk-one-login/frontend-ui": "5.0.0",
         "@govuk-one-login/frontend-vital-signs": "0.1.3",
-        "axios": "1.15.0",
+        "axios": "1.16.0",
         "connect-dynamodb": "3.0.3",
         "dotenv": "16.4.5",
         "express": "4.22.1",
@@ -4938,12 +4938,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -11853,7 +11853,7 @@
         "@aws-sdk/credential-providers": "3.1005.0",
         "@cucumber/cucumber": "12.8.2",
         "aws4-axios": "3.4.0",
-        "axios": "1.15.0",
+        "axios": "1.16.0",
         "chai": "4.3.8",
         "dotenv": "16.3.1",
         "playwright": "1.55.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6706,9 +6706,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -6717,7 +6717,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -11724,6 +11725,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
     "@govuk-one-login/frontend-ui": "5.0.0",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",
-    "axios": "1.15.0",
+    "axios": "1.16.0",
     "connect-dynamodb": "3.0.3",
     "dotenv": "16.4.5",
     "express": "4.22.1",

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -11,7 +11,7 @@
     "@aws-sdk/credential-providers": "3.1005.0",
     "@cucumber/cucumber": "12.8.2",
     "aws4-axios": "3.4.0",
-    "axios": "1.15.0",
+    "axios": "1.16.0",
     "chai": "4.3.8",
     "dotenv": "16.3.1",
     "playwright": "1.55.1",


### PR DESCRIPTION
## Proposed changes

### What changed
Bumped Axios to non vuln version and fast-xml-builder version

### Issue tracking
- [OJ-3678](https://govukverify.atlassian.net/browse/OJ-3678)


[OJ-3678]: https://govukverify.atlassian.net/browse/OJ-3678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ