### PR TITLE
chore: bump common-express to v15.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       ],
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.1005.0",
-        "@govuk-one-login/di-ipv-cri-common-express": "14.0.3",
+        "@govuk-one-login/di-ipv-cri-common-express": "15.0.2",
         "@govuk-one-login/frontend-analytics": "4.0.5",
         "@govuk-one-login/frontend-device-intelligence": "1.1.0",
         "@govuk-one-login/frontend-language-toggle": "1.1.0",
@@ -1540,12 +1540,11 @@
       }
     },
     "node_modules/@govuk-one-login/di-ipv-cri-common-express": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-14.0.3.tgz",
-      "integrity": "sha512-izV2t6iBMESkGpnw4OAxna2OnHS/uypzNSTTxEERwvl2wSUbyfgbxme9N9bFEpRt4HU/uWAktthVwDi7336Eag==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-15.0.2.tgz",
+      "integrity": "sha512-jE9HeM2nYukESu2UHRayzQ31aoy3ECa1tmHBnzH9yVO7pb8+AEKcdwAg9XQkw2MLLyJP4n19a1mS8Gmr8jBvkA==",
       "license": "MIT",
       "dependencies": {
-        "@govuk-one-login/frontend-ui": "5.0.0",
         "async": "3.2.6",
         "body-parser": "1.20.4",
         "compression": "1.8.1",
@@ -1578,11 +1577,20 @@
       "peerDependencies": {
         "@govuk-one-login/frontend-language-toggle": "^1.1.0",
         "@govuk-one-login/frontend-passthrough-headers": "^1.0.0",
+        "@govuk-one-login/frontend-ui": "^5.0.0",
         "express": "^4.21.0",
         "govuk-frontend": "^5.0.0",
-        "hmpo-components": "^8.0.5",
+        "hmpo-components": "^7.1.0 || ^8.0.5",
         "hmpo-form-wizard": ">=12.0.6",
         "nunjucks": "^3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "hmpo-components": {
+          "optional": true
+        },
+        "hmpo-form-wizard": {
+          "optional": true
+        }
       }
     },
     "node_modules/@govuk-one-login/di-ipv-cri-common-express/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.1005.0",
-    "@govuk-one-login/di-ipv-cri-common-express": "14.0.3",
+    "@govuk-one-login/di-ipv-cri-common-express": "15.0.2",
     "@govuk-one-login/frontend-analytics": "4.0.5",
     "@govuk-one-login/frontend-device-intelligence": "1.1.0",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",


### PR DESCRIPTION
## Proposed changes

### What changed
bump common-express to 15.0.2

### Why did it change
Includes changes to logging parity with pino and hmpo-logger

### Issue tracking
- [OJ-3677](https://govukverify.atlassian.net/browse/OJ-3677)

[OJ-3677]: https://govukverify.atlassian.net/browse/OJ-3677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ