### PR TITLE
OJ-3708: deploy pre-merge FE image to ECR

### DIFF
--- a/.github/workflows/push-pre-merge-test-image.yml
+++ b/.github/workflows/push-pre-merge-test-image.yml
@@ -33,5 +33,6 @@ jobs:
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
           repository: check-hmrc-front-pre-merge
           dockerfile: Dockerfile
+          build-args: BASE=plain
           image-version: ${{ github.sha }}
           image-tags: ${{ steps.tag.outputs.image-tag }}

--- a/.github/workflows/push-pre-merge-test-image.yml
+++ b/.github/workflows/push-pre-merge-test-image.yml
@@ -1,0 +1,37 @@
+name: Push pre-merge test Docker image
+
+on:
+  - pull_request
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  push-image:
+    name: Push pre-merge image
+    runs-on: ubuntu-latest
+    environment: development
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    concurrency:
+      group: push-pre-merge-test-image-${{ github.head_ref || github.ref_name }}
+      cancel-in-progress: true
+    steps:
+      - name: Derive image tag from branch name
+        id: tag
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        run: |
+          tag="$(printf '%s' "$BRANCH_NAME" | tr -c 'A-Za-z0-9_.-' '-')"
+          tag="${tag:0:128}"
+          echo "image-tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push pre-merge image to ECR
+        uses: govuk-one-login/github-actions/aws/ecr/build-docker-image@c8eefadf581d2087ce2af48b7060c1329cfa5251
+        with:
+          immutable-tags: false
+          aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
+          repository: check-hmrc-front-pre-merge
+          dockerfile: Dockerfile
+          image-version: ${{ github.sha }}
+          image-tags: ${{ steps.tag.outputs.image-tag }}

--- a/.github/workflows/push-pre-merge-test-image.yml
+++ b/.github/workflows/push-pre-merge-test-image.yml
@@ -30,7 +30,7 @@ jobs:
         uses: govuk-one-login/github-actions/aws/ecr/build-docker-image@c8eefadf581d2087ce2af48b7060c1329cfa5251
         with:
           immutable-tags: false
-          aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
+          aws-role-arn: ${{ secrets.DEV_PRE_MERGE_GHA_ROLE }}
           repository: check-hmrc-front-pre-merge
           dockerfile: Dockerfile
           build-args: BASE=plain

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # https://hub.docker.com/layers/library/node/22-alpine/images/sha256-cb15fca92530d7ac113467696cf1001208dac49c3c64355fd1348c11a88ddf8f
 ARG NODE_SHA=sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f
+ARG BASE=with_dynatrace
 FROM node:22-alpine@${NODE_SHA} AS builder
 WORKDIR /app
 
@@ -8,7 +9,7 @@ COPY /src ./src
 
 RUN npm ci && npm run build && npm prune
 
-FROM node:22-alpine@${NODE_SHA} AS final
+FROM node:22-alpine@${NODE_SHA} AS plain
 RUN apk --no-cache upgrade && apk add --no-cache tini curl
 
 WORKDIR /app
@@ -21,10 +22,6 @@ COPY --from=builder /app/package-lock.json ./
 COPY --from=builder /app/src ./src
 COPY --from=builder /app/.npmrc ./
 
-# Add in dynatrace layer
-COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs / /
-ENV LD_PRELOAD=/opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
-
 ENV PORT=8080
 EXPOSE $PORT
 
@@ -34,3 +31,9 @@ HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
 ENTRYPOINT ["sh", "-c", "export DT_HOST_ID=CHECK-HMRC-CRI-FRONT-$RANDOM && tini npm start"]
 
 CMD ["npm", "start"]
+
+FROM plain AS with_dynatrace
+COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs / /
+ENV LD_PRELOAD=/opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+FROM ${BASE} AS release


### PR DESCRIPTION
## Proposed changes

### What changed
Created a new workflow to deploy a pre-merge FE image without DT to `check-hmrc-front-pre-merge` ECR repo.

### Why did it change
This will enable us to deploy custom pre-merge frontends for our integration tests. 

## Screenshot of what gets deployed in ECR
Note: I tested 2 deploys with 2 branches, tag contains branch name
OJ-3708 (this one) and test-sk-test (second test branch)

<img width="800" alt="Screenshot 2026-06-11 at 11 42 44" src="https://github.com/user-attachments/assets/5db23ca0-47f0-4020-930f-1de6c6848945" />



### Issue tracking
- [OJ-3708](https://govukverify.atlassian.net/browse/OJ-3708)


[OJ-3708]: https://govukverify.atlassian.net/browse/OJ-3708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ