### PR TITLE
feat: create GHA to deploy pre-merge stack

### DIFF
--- a/.github/workflows/deploy-pre-merge-stack.yml
+++ b/.github/workflows/deploy-pre-merge-stack.yml
@@ -1,0 +1,81 @@
+name: Deploy pre-merge FE stack
+
+on:
+  workflow_run:
+    workflows:
+      - Push pre-merge test Docker image
+    types:
+      - completed
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-pre-merge-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: SAM build
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    environment: development
+    outputs:
+      cache-key: ${{ steps.build.outputs.cache-key }}
+      cache-restore-keys: ${{ steps.build.outputs.cache-restore-keys }}
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Build SAM application
+        id: build
+        uses: govuk-one-login/github-actions/sam/build-application@e6b6ed890b35904e1be79f7f35ffec983fa4d9db
+        with:
+          template: deploy/template.yaml
+
+  deploy:
+    name: Deploy pre-merge stack
+    needs: build
+    runs-on: ubuntu-latest
+    environment: development
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Derive container image override from branch
+        id: image
+        env:
+          BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          tag="$(printf '%s' "$BRANCH_NAME" | tr -c 'A-Za-z0-9_.-' '-')"
+          tag="${tag:0:128}"
+          echo "uri=562670266496.dkr.ecr.eu-west-2.amazonaws.com/check-hmrc-front-pre-merge:${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy stack
+        id: deploy
+        uses: govuk-one-login/github-actions/sam/deploy-stack@e6b6ed890b35904e1be79f7f35ffec983fa4d9db
+        with:
+          template: deploy/template.yaml
+          sam-deployment-bucket: ${{ vars.DEPLOYMENT_ARTIFACTS_BUCKET }}
+          aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
+          stack-name-prefix: preview-check-hmrc-front
+          cache-key: ${{ needs.build.outputs.cache-key }}
+          cache-restore-keys: ${{ needs.build.outputs.cache-restore-keys }}
+          s3-prefix: preview
+          pull-repository: false
+          delete-failed-stack: true
+          tags: |
+            cri:component=ipv-cri-check-hmrc-front
+            cri:stack-type=preview
+            cri:application=Orange
+            cri:deployment-source=github-actions
+          parameters: |
+            Environment=dev
+            PreMerge=true
+            VpcStackName=cri-vpc
+            ContainerImageNameOverride=${{ steps.image.outputs.uri }}


### PR DESCRIPTION
## Proposed changes

### What changed
Create GHA to deploy FE pre-merge

### Why did it change
This will enable pre-merge FE testing

### Issue tracking
- [OJ-3709](https://govukverify.atlassian.net/browse/OJ-3709)


[OJ-3709]: https://govukverify.atlassian.net/browse/OJ-3709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ