### PR TITLE
feat: create post-merge-cleanup.yml

### DIFF
--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -1,0 +1,38 @@
+name: Post-merge cleanup
+run-name: ${{ github.event.pull_request.title || format('Delete pre-merge stack [{0}]', github.head_ref || github.ref_name) }}
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [closed]
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: pre-merge-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  delete-stack:
+    name: Delete pre-merge stack
+    runs-on: ubuntu-latest
+    environment: development
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Get stack name
+        id: get-stack-name
+        uses: govuk-one-login/github-actions/beautify-branch-name@e6b6ed890b35904e1be79f7f35ffec983fa4d9db
+        with:
+          usage: Stack name
+          prefix: preview-check-hmrc-front
+          length-limit: 128
+          verbose: false
+
+      - name: Delete stack
+        uses: govuk-one-login/github-actions/sam/delete-stacks@e6b6ed890b35904e1be79f7f35ffec983fa4d9db
+        with:
+          stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }}
+          aws-role-arn: ${{ secrets.DEV_PRE_MERGE_GHA_ROLE }}
+          verbose: true


### PR DESCRIPTION
## Proposed changes

### What changed
Added a GHA to delete pre-merge stacks when PR is closed

### Why did it change
To prevent build up of stale preview stacks.

### Issue tracking
- [OJ-3710](https://govukverify.atlassian.net/browse/OJ-3710)


[OJ-3710]: https://govukverify.atlassian.net/browse/OJ-3710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ