### PR TITLE
OJ-3728: chore - update post merge image to 1.61.0

### DIFF
--- a/test/browser/post-merge.Dockerfile
+++ b/test/browser/post-merge.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.55.1-jammy
+FROM mcr.microsoft.com/playwright:v1.61.0-noble
 
 RUN apt-get update && apt-get install unzip
 RUN wget -O "awscliv2.zip" "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" && unzip awscliv2.zip && ./aws/install

--- a/test/browser/support/setup.js
+++ b/test/browser/support/setup.js
@@ -42,10 +42,11 @@ AfterAll(async function () {
 
 Before(async function ({ pickle } = {}) {
   // Only if USE_LOCAL_API do we use the @mock-api -> client_id mapping
-  if (!(
+  const localApi =
     process.env.USE_LOCAL_API === "true" ||
-    process.env.USE_LOCAL_API === undefined
-  )) {
+    process.env.USE_LOCAL_API === undefined;
+
+  if (!localApi) {
     return;
   }
 

--- a/test/browser/support/setup.js
+++ b/test/browser/support/setup.js
@@ -42,11 +42,7 @@ AfterAll(async function () {
 
 Before(async function ({ pickle } = {}) {
   // Only if USE_LOCAL_API do we use the @mock-api -> client_id mapping
-  const localApi =
-    process.env.USE_LOCAL_API === "true" ||
-    process.env.USE_LOCAL_API === undefined;
-
-  if (!localApi) {
+  if (process.env.USE_LOCAL_API === "false") {
     return;
   }
 

--- a/test/browser/support/setup.js
+++ b/test/browser/support/setup.js
@@ -42,12 +42,10 @@ AfterAll(async function () {
 
 Before(async function ({ pickle } = {}) {
   // Only if USE_LOCAL_API do we use the @mock-api -> client_id mapping
-  if (
-    !(
-      process.env.USE_LOCAL_API === "true" ||
-      process.env.USE_LOCAL_API === undefined
-    )
-  ) {
+  if (!(
+    process.env.USE_LOCAL_API === "true" ||
+    process.env.USE_LOCAL_API === undefined
+  )) {
     return;
   }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Update post merge docker image playwright version to match pre-merge.
- Refactored the `Before` method to fix prettier and eslint conflict (prettier wanted no spacing, eslint wanted extra spacing).

### Why did it change
To enable pipeline runs. As this was the error:
<img width="1468" height="646" alt="image" src="https://github.com/user-attachments/assets/47370343-cc81-40ac-8943-fb4336b8c9d2" />


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3278](https://govukverify.atlassian.net/browse/OJ-3278)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


[OJ-3278]: https://govukverify.atlassian.net/browse/OJ-3278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ