### PR TITLE
OJ-3696: Upgrade common-express to resolve i18next vulns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       ],
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.1005.0",
-        "@govuk-one-login/di-ipv-cri-common-express": "15.0.3",
+        "@govuk-one-login/di-ipv-cri-common-express": "16.0.2",
         "@govuk-one-login/frontend-analytics": "4.0.5",
         "@govuk-one-login/frontend-device-intelligence": "1.1.0",
         "@govuk-one-login/frontend-language-toggle": "1.1.0",
@@ -1540,9 +1540,9 @@
       }
     },
     "node_modules/@govuk-one-login/di-ipv-cri-common-express": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-15.0.3.tgz",
-      "integrity": "sha512-oENYHri25l+26qSH9eam6OxqmwzU3ffY+KUYYqL9XoE3KHAkrMd0gP+MOm4QTmaIsHv15M+sIIcUzmI4qbqwgw==",
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-16.0.2.tgz",
+      "integrity": "sha512-gijTbI6+Hggao1cRY9hujKbHMGLdfA8OqQsLf0hdNRzDbCuMO3Ko58ae03l/oqCAoWqGkpYOG2XkBXSw8gFVYg==",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",
@@ -1560,8 +1560,8 @@
         "hmpo-i18n": "7.0.1",
         "hmpo-logger": "7.0.1",
         "i18next": "23.8.1",
-        "i18next-fs-backend": "2.6.5",
-        "i18next-http-middleware": "3.9.6",
+        "i18next-fs-backend": "2.6.6",
+        "i18next-http-middleware": "3.9.7",
         "lodash.differencewith": "4.5.0",
         "nocache": "3.0.4",
         "on-finished": "2.4.1",
@@ -5951,15 +5951,15 @@
       }
     },
     "node_modules/i18next-fs-backend": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.5.tgz",
-      "integrity": "sha512-+7HBrlaj3UFnNC9HqiXaIlNkwNINYkgQ2PS4h7qW/WGHC9/+OU9Xi0/tdvjjXATw3YCcpmNV7S3zDD9e10pTWg==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.6.tgz",
+      "integrity": "sha512-mYGu6Nt8RIp3X/U8Y+Gej1wo5xmYWmGKLqBGMCC2OCAou5rW5epeHgHmVcw20mJs9Z9+DAPHIxQPNCgFyPRMeg==",
       "license": "MIT"
     },
     "node_modules/i18next-http-middleware": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-3.9.6.tgz",
-      "integrity": "sha512-zKOft9iNCbOM4cWxThpq9gikpCuftCFh9s7V+vXPoB0+AJw13mXZe/O2VCfZO0AKNHplFTDYkJASoK+J3iWFeQ==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-3.9.7.tgz",
+      "integrity": "sha512-k4Aa39thnQXGox5ZeKvlOwbDsFz+iGxtPJITWm6xmmErNZOeGMXIoH9XwK3ITUq7lqHaywnIH9gLwOraU4jJvQ==",
       "license": "MIT"
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.1005.0",
-    "@govuk-one-login/di-ipv-cri-common-express": "15.0.3",
+    "@govuk-one-login/di-ipv-cri-common-express": "16.0.2",
     "@govuk-one-login/frontend-analytics": "4.0.5",
     "@govuk-one-login/frontend-device-intelligence": "1.1.0",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",


### PR DESCRIPTION
## Proposed changes

### What changed

- Upgraded common-express to v16.0.2

### Why did it change

- https://github.com/govuk-one-login/ipv-cri-check-hmrc-front/security/dependabot/151
- https://github.com/govuk-one-login/ipv-cri-check-hmrc-front/security/dependabot/152

### Issue tracking

- OJ-3696

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
