### PR TITLE
feat: bump common-express to v16.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       ],
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.1005.0",
-        "@govuk-one-login/di-ipv-cri-common-express": "16.0.3",
+        "@govuk-one-login/di-ipv-cri-common-express": "16.1.0",
         "@govuk-one-login/frontend-analytics": "4.0.5",
         "@govuk-one-login/frontend-device-intelligence": "1.1.0",
         "@govuk-one-login/frontend-language-toggle": "1.1.0",
@@ -1487,9 +1487,9 @@
       }
     },
     "node_modules/@govuk-one-login/di-ipv-cri-common-express": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-16.0.3.tgz",
-      "integrity": "sha512-y5qPkAokEtBws41mzm8G/eEKSQ5kObOYfQBNBysLbFXnXbwjEarV6PJzR+iEn4SxLsWwEBzPgBHYw65fZNZ4LA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-16.1.0.tgz",
+      "integrity": "sha512-K1k8/mrX5jp+RSl5F9RwMmE1wR2aMlmaKlT3e212SsUW2KHNn3d4pRR9Vo4UVllAd4+EylAGULpgrpkKwQM8tg==",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.1005.0",
-    "@govuk-one-login/di-ipv-cri-common-express": "16.0.3",
+    "@govuk-one-login/di-ipv-cri-common-express": "16.1.0",
     "@govuk-one-login/frontend-analytics": "4.0.5",
     "@govuk-one-login/frontend-device-intelligence": "1.1.0",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",


### PR DESCRIPTION
## Proposed changes

### Why did it change
v16.1.0 allows us to see the `govuk_signin_journey_id` in our logs which will allows us to correlate BE/FE logs together.

### Issue tracking
- [OJ-3667](https://govukverify.atlassian.net/browse/OJ-3667)


[OJ-3667]: https://govukverify.atlassian.net/browse/OJ-3667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ