### PR TITLE
feat: create a new WebACL and association for pre-merge stacks

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -64,6 +64,7 @@ Parameters:
 
 Conditions:
   IsNotPreMergeStack: !Equals [!Ref PreMerge, "false"]
+  IsPreMergeStack: !Equals [!Ref PreMerge, "true"]
 
   UseContainerImageNameOverride:
     !Not [!Equals [!Ref ContainerImageNameOverride, ""]]
@@ -840,6 +841,43 @@ Resources:
     Properties:
       ResourceArn: !Ref LoadBalancer
       WebACLArn: !ImportValue cfront-origin-distrib-CloakingOriginWebACLArn
+
+  PreMergeLoadBalancerWebACL:
+    Type: AWS::WAFv2::WebACL
+    Condition: IsPreMergeStack
+    Properties:
+      Name: !Sub "${AWS::StackName}-premerge-acl"
+      Scope: REGIONAL
+      DefaultAction:
+        Allow: {}
+      VisibilityConfig:
+        SampledRequestsEnabled: true
+        CloudWatchMetricsEnabled: true
+        MetricName: !Sub "${AWS::StackName}-premerge-acl"
+      Rules:
+        - Name: AWS-CommonRuleSet
+          Priority: 0
+          OverrideAction:
+            None: {}
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+              RuleActionOverrides:
+                - Name: SizeRestrictions_QUERYSTRING
+                  ActionToUse:
+                    Count: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AWS-CommonRuleSet
+
+  PreMergeWAFv2ACLAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Condition: IsPreMergeStack
+    Properties:
+      ResourceArn: !Ref LoadBalancer
+      WebACLArn: !GetAtt PreMergeLoadBalancerWebACL.Arn
 
   # ECS Autoscaling
 


### PR DESCRIPTION
## Proposed changes

### Why did it change
Pre-merge stacks are reached directly on the API Gateway URL (they have no CloudFront domain), and the existing `CloudFrontWAFv2ACLAssociation` is skipped for them (`IsNotPreMergeStack`). That leaves the ALB with no WebACL of its own, so AWS Firewall Manager fills the gap and attaches its org-managed WebACL (`FMManagedWebACLV2-*`).

That managed WebACL includes the AWS Core Rule Set with `SizeRestrictions_QUERYSTRING` at its default action of Block, which rejects any query string over 2,048 bytes. The OAuth authorize `request` JAR (client_id + encrypted/signed request) routinely exceeds that, so `/oauth2/authorize?...&request=<JAR>` is blocked at the ALB with a 403 (`server: awselb/2.0`) before it ever reaches the frontend.

## Screenshot of success
<img width="2538" height="1314" alt="Screenshot 2026-07-28 at 12 35 43" src="https://github.com/user-attachments/assets/3d2574ab-e12e-42d7-9ac2-944f3f6b15c9" />



